### PR TITLE
Added the "-insecure" flag to the command line

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,17 +13,18 @@ type App struct {
 	args []string
 	flag *flag.FlagSet
 
-	Command     string
-	Local       HostInput
-	Remote      HostInput
-	Server      HostInput
-	Key         string
-	Verbose     bool
-	Help        bool
-	Version     bool
-	Alias       string
-	Start       string
-	AliasDelete bool
+	Command      string
+	Local        HostInput
+	Remote       HostInput
+	Server       HostInput
+	Key          string
+	Verbose      bool
+	Help         bool
+	Version      bool
+	Alias        string
+	Start        string
+	AliasDelete  bool
+	InsecureMode bool
 }
 
 func New(args []string) *App {
@@ -43,6 +44,7 @@ func (c *App) Parse() error {
 	f.BoolVar(&c.Verbose, "v", false, "(optional) Increase log verbosity")
 	f.BoolVar(&c.Help, "help", false, "list all options available")
 	f.BoolVar(&c.Version, "version", false, "display the mole version")
+	f.BoolVar(&c.InsecureMode, "insecure", false, "(optional) ignore unknown host keys when connecting to an ssh server")
 
 	f.Parse(c.args[1:])
 

--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -80,6 +80,8 @@ func start(app cli.App) error {
 		return err
 	}
 
+	s.SetInsecureMode(app.InsecureMode)
+
 	log.Debugf("server: %s", s)
 
 	t := tunnel.New(app.Local.String(), s, app.Remote.String())

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -17,10 +17,11 @@ import (
 
 // Server holds the SSH Server attributes used for the client to connect to it.
 type Server struct {
-	Name    string
-	Address string
-	User    string
-	Key     string
+	Name     string
+	Address  string
+	User     string
+	Key      string
+	insecure bool
 }
 
 // NewServer creates a new instance of Server using $HOME/.ssh/config to
@@ -89,6 +90,11 @@ func NewServer(user, address, key string) (*Server, error) {
 // String provided a string representation of a Server.
 func (s Server) String() string {
 	return fmt.Sprintf("[name=%s, address=%s, user=%s, key=%s]", s.Name, s.Address, s.User, s.Key)
+}
+
+// Set whether or not to check the known_hosts file
+func (s *Server) SetInsecureMode(flag bool) {
+	s.insecure = flag
 }
 
 // Tunnel represents the ssh tunnel used to forward a local connection to a
@@ -225,7 +231,7 @@ func sshClientConfig(server Server) (*ssh.ClientConfig, error) {
 		return nil, err
 	}
 
-	callback, err := knownHostsCallback()
+	callback, err := knownHostsCallback(server)
 	if err != nil {
 		return nil, err
 	}
@@ -247,16 +253,22 @@ func copyConn(writer, reader net.Conn) {
 	}
 }
 
-func knownHostsCallback() (ssh.HostKeyCallback, error) {
+func knownHostsCallback(s Server) (ssh.HostKeyCallback, error) {
 	knownHostFile := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
 
 	log.Debugf("known_hosts file used: %s", knownHostFile)
 
-	callback, err := knownhosts.New(knownHostFile)
+	secureCallback, err := knownhosts.New(knownHostFile)
 	if err != nil {
 		return nil, fmt.Errorf("error while parsing 'known_hosts' file: %s: %v", knownHostFile, err)
 	}
 
+	callback := func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if s.insecure {
+			return nil
+		}
+		return secureCallback(hostname, remote, key)
+	}
 	return callback, nil
 }
 


### PR DESCRIPTION
This change was rather simple once implemented. The callback function for the host checking is instead used in an anonymous internal function so that this option could be toggled at runtime with ease in the future by toggling `insecure` on the Server struct.  Closes #11 