### PR TITLE
Use LocalForward option from SSH config file 

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -86,12 +86,17 @@ func (c App) Validate() error {
 	}
 
 	switch c.Command {
-	case "start", "new-alias":
+	case "new-alias":
 		if c.Remote.String() == "" {
 			return fmt.Errorf("required flag is missing: -remote")
 		} else if c.Server.String() == "" {
 			return fmt.Errorf("required flag is missing: -server")
 		}
+	case "start":
+		if c.Server.String() == "" {
+			return fmt.Errorf("required flag is missing: -server")
+		}
+
 	}
 	return nil
 }

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -38,21 +38,17 @@ func NewServer(user, address, key string) (*Server, error) {
 		port = args[1]
 	}
 
-	c := filepath.Join(os.Getenv("HOME"), ".ssh", "config")
-	if _, err := os.Stat(c); err != nil {
+	c, err := NewSSHConfigFile()
+	if err != nil {
 		hostname = host
-	} else {
-		c, err := NewSSHConfigFile(c)
-		if err != nil {
-			return nil, fmt.Errorf("error accessing %s: %v", host, err)
-		}
-
-		h := c.Get(host)
-		hostname = reconcileHostname(host, h.Hostname)
-		port = reconcilePort(port, h.Port)
-		user = reconcileUser(user, h.User)
-		key = reconcileKey(key, h.Key)
+		return nil, fmt.Errorf("error accessing %s: %v", host, err)
 	}
+
+	h := c.Get(host)
+	hostname = reconcileHostname(host, h.Hostname)
+	port = reconcilePort(port, h.Port)
+	user = reconcileUser(user, h.User)
+	key = reconcileKey(key, h.Key)
 
 	if host == "" {
 		return nil, fmt.Errorf("server host has to be provided as part of the server address")
@@ -102,16 +98,14 @@ type Tunnel struct {
 
 // New creates a new instance of Tunnel.
 func New(localAddress string, server *Server, remoteAddress string) *Tunnel {
-
-	if localAddress == "" {
-		localAddress = "127.0.0.1:0"
-	} else if strings.HasPrefix(localAddress, ":") {
-		localAddress = fmt.Sprintf("127.0.0.1%s", localAddress)
+	cfg, err := NewSSHConfigFile()
+	if err != nil {
+		log.Warningf("error to read ssh config: %v", err)
 	}
 
-	if strings.HasPrefix(remoteAddress, ":") {
-		remoteAddress = fmt.Sprintf("127.0.0.1%s", remoteAddress)
-	}
+	sh := cfg.Get(server.Name)
+	localAddress = reconcileLocal(localAddress, sh.LocalForward.Local)
+	remoteAddress = reconcileRemote(remoteAddress, sh.LocalForward.Remote)
 
 	return &Tunnel{
 		local:  localAddress,
@@ -306,4 +300,31 @@ func reconcileKey(givenKey, resolvedKey string) string {
 	}
 
 	return ""
+}
+
+func reconcileLocal(givenLocal, resolvedLocal string) string {
+
+	if givenLocal == "" && resolvedLocal != "" {
+		return resolvedLocal
+	}
+	if givenLocal == "" {
+		return "127.0.0.1:0"
+	}
+	if strings.HasPrefix(givenLocal, ":") {
+		return fmt.Sprintf("127.0.0.1%s", givenLocal)
+	}
+
+	return givenLocal
+}
+
+func reconcileRemote(givenRemote, resolvedRemote string) string {
+
+	if givenRemote == "" && resolvedRemote != "" {
+		return resolvedRemote
+	}
+	if strings.HasPrefix(givenRemote, ":") {
+		return fmt.Sprintf("127.0.0.1%s", givenRemote)
+	}
+
+	return givenRemote
 }


### PR DESCRIPTION
Use LocalForward option from SSH config file when local and remote options are absent #13 