### PR TITLE
Fail build if code is not formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
 LDFLAGS := -X main.version=$(version)
 
-.install:
+test:
+ifneq ($(shell go fmt ./...),)
+	$(error code not formatted. Please run 'go fmt')
+endif
+	@go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic
+cover: test
+	go tool cover -html=coverage.txt
+
+install:
 	@go install github.com/davrodpin/mole/cmd/mole
-.bin:
+
+bin:
 ifeq ($(version),)
 	$(error usage: make bin version=X.Y.Z)
 endif
@@ -10,11 +19,6 @@ endif
 	cd bin && tar c mole | gzip > mole$(version).darwin-amd64.tar.gz && rm mole && cd -
 	GOOS=linux GOARCH=amd64 go build -o bin/mole -ldflags "$(LDFLAGS)" github.com/davrodpin/mole/cmd/mole
 	cd bin && tar c mole | gzip > mole$(version).linux-amd64.tar.gz && rm mole && cd -
-test:
-	@go test ./... -race -coverprofile=coverage.txt -covermode=atomic
-.cover: test
-	go tool cover -html=coverage.txt
-
 
 add-network:
 	-@docker network create --subnet=192.168.33.0/24 mole


### PR DESCRIPTION
This change adds a new safe guard to fail tests if the code is not
formatted using 'go fmt'.