### PR TITLE
Fix warn log messages related to LocalForward

### DIFF
--- a/tunnel/config.go
+++ b/tunnel/config.go
@@ -90,6 +90,10 @@ func (r SSHConfigFile) getLocalForward(host string) (*LocalForward, error) {
 		return nil, err
 	}
 
+	if c == "" {
+		return &LocalForward{Local: "", Remote: ""}, nil
+	}
+
 	l := strings.Fields(c)
 
 	if len(l) < 2 {
@@ -138,13 +142,18 @@ type SSHHost struct {
 	LocalForward *LocalForward
 }
 
+// String returns a string representation of a SSHHost.
+func (h SSHHost) String() string {
+	return fmt.Sprintf("[hostname=%s, port=%s, user=%s, key=%s, local_forward=%s]", h.Hostname, h.Port, h.User, h.Key, h.LocalForward)
+}
+
 // LocalForward represents a LocalForward configuration for SSHHost.
 type LocalForward struct {
 	Local  string
 	Remote string
 }
 
-// String returns a string representation of a SSHHost.
-func (h SSHHost) String() string {
-	return fmt.Sprintf("[hostname=%s, port=%s, user=%s, key=%s]", h.Hostname, h.Port, h.User, h.Key)
+// String returns a string representation of LocalForward.
+func (f LocalForward) String() string {
+	return fmt.Sprintf("[local=%s, remote=%s]", f.Local, f.Remote)
 }

--- a/tunnel/config_test.go
+++ b/tunnel/config_test.go
@@ -1,0 +1,72 @@
+package tunnel
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kevinburke/ssh_config"
+)
+
+func TestSSHConfigFile(t *testing.T) {
+
+	var config = `
+Host example1
+  Hostname 172.17.0.1
+	Port 3306
+	User john
+	IdentityFile /path/.ssh/id_rsa
+Host example2
+	LocalForward 8080 127.0.0.1:8080
+Host example3
+	LocalForward 9090 127.0.0.1:9090
+`
+
+	c, _ := ssh_config.Decode(strings.NewReader(config))
+	cfg := &SSHConfigFile{sshConfig: c}
+
+	tests := []struct {
+		host     string
+		expected *SSHHost
+	}{
+		{
+			"example1",
+			&SSHHost{
+				Hostname:     "172.17.0.1",
+				Port:         "3306",
+				User:         "john",
+				Key:          "/path/.ssh/id_rsa",
+				LocalForward: &LocalForward{Local: "", Remote: ""},
+			},
+		},
+		{
+			"example2",
+			&SSHHost{
+				Hostname:     "example2",
+				Port:         "",
+				User:         "",
+				Key:          "",
+				LocalForward: &LocalForward{Local: "127.0.0.1:8080", Remote: "127.0.0.1:8080"},
+			},
+		},
+		{
+			"example3",
+			&SSHHost{
+				Hostname:     "example3",
+				Port:         "",
+				User:         "",
+				Key:          "",
+				LocalForward: &LocalForward{Local: "127.0.0.1:9090", Remote: "127.0.0.1:9090"},
+			},
+		},
+	}
+
+	var value *SSHHost
+	for _, test := range tests {
+		value = cfg.Get(test.host)
+
+		if !reflect.DeepEqual(test.expected, value) {
+			t.Errorf("unexpected result for %s:\n\texpected: %s\n\tvalue   : %s", test.host, test.expected, value)
+		}
+	}
+}


### PR DESCRIPTION
This change fixes the warning messages related to bad `LocalForward`
parsing from $HOME/.ssh/config.

Closes: #42