### PR TITLE
Remove third-party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 [![Documentation](https://godoc.org/github.com/davrodpin/mole?status.svg)](http://godoc.org/github.com/davrodpin/mole)
-[![Build Status](https://travis-ci.org/davrodpin/mole.svg?branch=master)](https://travis-ci.org/davrodpin/mole)
-[![Go Report Card](https://goreportcard.com/badge/github.com/davrodpin/mole)](https://goreportcard.com/report/github.com/davrodpin/mole)
-[![codebeat badge](https://codebeat.co/badges/ec5e4267-3292-4ef4-818c-b58e94a5dbbb)](https://codebeat.co/projects/github-com-davrodpin-mole-master)
-[![codecov](https://codecov.io/gh/davrodpin/mole/branch/master/graph/badge.svg)](https://codecov.io/gh/davrodpin/mole)
 # [Mole](https://davrodpin.github.io/mole/)
 
 Mole is a cli application to create ssh tunnels, forwarding a local port to a


### PR DESCRIPTION
This change remove the badges from the README.md since all quality
checks will not be made through Github Actions.