### PR TITLE
Report coverage diff from previous commit

### DIFF
--- a/.github/actions/report/Dockerfile
+++ b/.github/actions/report/Dockerfile
@@ -3,13 +3,13 @@ FROM debian:9.7
 LABEL "com.github.actions.name"="action-report"
 LABEL "com.github.actions.description"="Create quality reports for Mole"
 LABEL "com.github.actions.icon"="archive"
-LABEL "com.github.actions.color"="orange"
+LABEL "com.github.actions.color"="blue"
 
 LABEL "repository"="http://github.com/davrodpin/mole"
 LABEL "homepage"="https://davrodpin.github.io/mole/"
 LABEL "maintainer"="David Pinheiro <davrodpin@gmail.com>"
 
-RUN apt-get update && apt install -y curl build-essential jq
+RUN apt-get update && apt install -y curl build-essential jq bc
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -1,16 +1,16 @@
-# Mole Checks
+# Mole Quality Report Generator
 
-Github Action to validate new changes on [Mole](https://github.com/davrodpin/mole)
+ [Mole](https://github.com/davrodpin/mole)'s Github Action to generate quality
+ metric reports.
 
 ## Environment Variables
 
-Environment variables the action uses.
-
-  * `GO_VERSION`: The version of the Go compiler used to compile and test the change (default: 1.11.5)
+  * `GO_VERSION`: The version of the Go compiler used to generate the reports
+    (default: 1.11.5)
 
 ## Secrets
 
-  * `GITHUB_TOKEN`: Used to publish the new coverage report to Mole's source code repository
+  * `GITHUB_TOKEN`: Used to publish reports on Mole's source code repository.
 
 ## Required Arguments
 

--- a/.github/actions/syntax/README.md
+++ b/.github/actions/syntax/README.md
@@ -1,16 +1,16 @@
-# Mole Checks
+# Mole Syntax Checker
 
-Github Action to validate new changes on [Mole](https://github.com/davrodpin/mole)
+ [Mole](https://github.com/davrodpin/mole)'s Github Action to check for syntax
+errors in the source code.
 
 ## Environment Variables
 
-Environment variables the action uses.
-
-  * `GO_VERSION`: The version of the Go compiler used to compile and test the change (default: 1.11.5)
+  * `GO_VERSION`: The version of the Go compiler used to generate the reports
+    (default: 1.11.5)
 
 ## Secrets
 
-  * `GITHUB_TOKEN`: Used to publish the new coverage report to Mole's source code repository
+N/A
 
 ## Required Arguments
 

--- a/.github/actions/syntax/entrypoint.sh
+++ b/.github/actions/syntax/entrypoint.sh
@@ -61,11 +61,4 @@ mole_syntax() {
   return $retcode
 }
 
-case "$1" in
-  "syntax")
-    mole_syntax
-    ;;
-  *)
-    sh -c "$*"
-    ;;
-esac
+mole_syntax

--- a/.github/actions/test/Dockerfile
+++ b/.github/actions/test/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:9.7
 LABEL "com.github.actions.name"="action-test"
 LABEL "com.github.actions.description"="Execute Mole's tests"
 LABEL "com.github.actions.icon"="box"
-LABEL "com.github.actions.color"="orange"
+LABEL "com.github.actions.color"="purple"
 
 LABEL "repository"="http://github.com/davrodpin/mole"
 LABEL "homepage"="https://davrodpin.github.io/mole/"

--- a/.github/actions/test/README.md
+++ b/.github/actions/test/README.md
@@ -1,16 +1,16 @@
-# Mole Checks
+# Mole Test Runner
 
-Github Action to validate new changes on [Mole](https://github.com/davrodpin/mole)
+ [Mole](https://github.com/davrodpin/mole)'s Github Action to execute test
+ suites.
 
 ## Environment Variables
 
-Environment variables the action uses.
-
-  * `GO_VERSION`: The version of the Go compiler used to compile and test the change (default: 1.11.5)
+  * `GO_VERSION`: The version of the Go compiler used to generate the reports
+    (default: 1.11.5)
 
 ## Secrets
 
-  * `GITHUB_TOKEN`: Used to publish the new coverage report to Mole's source code repository
+N/A
 
 ## Required Arguments
 

--- a/.github/actions/test/entrypoint.sh
+++ b/.github/actions/test/entrypoint.sh
@@ -55,11 +55,4 @@ mole_test() {
   return 0
 }
 
-case "$1" in
-  "test")
-    mole_test
-    ;;
-  *)
-    sh -c "$*"
-    ;;
-esac
+mole_test

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,7 +8,6 @@ action "Check Syntax" {
   env = {
     GO_VERSION = "1.11.5"
   }
-  args = [ "syntax" ]
 }
 
 action "Run Tests" {
@@ -16,12 +15,13 @@ action "Run Tests" {
   env = {
     GO_VERSION = "1.11.5"
   }
-  args = [ "test" ]
 }
 
 action "Create Report" {
   needs = [ "Run Tests" ]
   uses = "./.github/actions/report"
-  args = [ "report" ]
+  env = {
+    GO_VERSION = "1.11.5"
+  }
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
This change adds the code coverage diff between the current and previous
commits. The numbers are getting printed to the standard output.