### PR TITLE
Change the cov. report repo to dropbox

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -23,5 +23,5 @@ action "Create Report" {
   env = {
     GO_VERSION = "1.11.5"
   }
-  secrets = ["GITHUB_TOKEN"]
+  secrets = ["DROPBOX_TOKEN"]
 }


### PR DESCRIPTION
This change moves the coverate report archive to dropbox instead of the
source code repository itself.