### PR TITLE
Keep SSH connection alive

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var re = regexp.MustCompile(`(?P<user>.+@)?(?P<host>[[:alpha:][:digit:]\_\-\.]+)?(?P<port>:[0-9]+)?`)
@@ -15,21 +16,22 @@ type App struct {
 	args []string
 	flag *flag.FlagSet
 
-	Command      string
-	Local        AddressInputList
-	Remote       AddressInputList
-	Server       AddressInput
-	Key          string
-	Verbose      bool
-	Help         bool
-	Version      bool
-	Alias        string
-	Start        string
-	AliasDelete  bool
-	Detach       bool
-	Stop         string
-	AliasList    bool
-	InsecureMode bool
+	Command           string
+	Local             AddressInputList
+	Remote            AddressInputList
+	Server            AddressInput
+	Key               string
+	Verbose           bool
+	Help              bool
+	Version           bool
+	Alias             string
+	Start             string
+	AliasDelete       bool
+	Detach            bool
+	Stop              string
+	AliasList         bool
+	InsecureMode      bool
+	KeepAliveInterval time.Duration
 }
 
 // New creates a new instance of App.
@@ -57,6 +59,7 @@ func (c *App) Parse() error {
 	f.BoolVar(&c.Detach, "detach", false, "(optional) run process in background")
 	f.StringVar(&c.Stop, "stop", "", "stop background process")
 	f.BoolVar(&c.InsecureMode, "insecure", false, "(optional) skip host key validation when connecting to ssh server")
+	f.DurationVar(&c.KeepAliveInterval, "keep-alive-interval", 10*time.Second, "(optional) time interval for keep alive packets to be sent")
 
 	f.Parse(c.args[1:])
 
@@ -111,8 +114,8 @@ func (c App) Validate() error {
 // use the tool.
 func (c *App) PrintUsage() {
 	fmt.Fprintf(os.Stderr, "%s\n\n", `usage:
-	mole [-v] [-insecure] [-detach] (-local [<host>]:<port>)... (-remote [<host>]:<port>)... -server [<user>@]<host>[:<port>] [-key <key_path>]
-	mole -alias <alias_name> [-v] (-local [<host>]:<port>)... (-remote [<host>]:<port>)... -server [<user>@]<host>[:<port>] [-key <key_path>]
+	mole [-v] [-insecure] [-detach] (-local [<host>]:<port>)... (-remote [<host>]:<port>)... -server [<user>@]<host>[:<port>] [-key <key_path>] [-keep-alive-interval <time_interval>]
+	mole -alias <alias_name> [-v] (-local [<host>]:<port>)... (-remote [<host>]:<port>)... -server [<user>@]<host>[:<port>] [-key <key_path>] [-keep-alive-interval <time_interval>]
 	mole -alias <alias_name> -delete
 	mole -start <alias_name>
 	mole -help

--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -269,6 +269,8 @@ func start(app *cli.App) error {
 		return err
 	}
 
+	t.KeepAliveInterval = app.KeepAliveInterval
+
 	if err = t.Start(); err != nil {
 		log.WithFields(log.Fields{
 			"tunnel": t.String(),

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -62,6 +62,8 @@ This port is published on the local computer using port `22122`, so ssh
 connections can be made using address `127.0.0.1:22122`.
 All ssh connection to `mole_ssh` should be done using the user `mole` and the
 key file located on `test-env/key`
+The ssh server is configured to end any connections that is idle for three (3)
+or more seconds.
 
 `mole_http` runs two http servers listening on port `80` and `8080`, so clients
 would be able to access the using the following urls: `http://192.168.33.11:80/`
@@ -84,7 +86,7 @@ The ssh authentication key files, `test-env/key` and `test-env/key,pub` will
 ```sh
 $ make test-env
 <lots of output messages here>
-$ mole -insecure -local :21112 -local :21113 -remote 192.168.33.11:80 -remote 192.168.33.11:8080 -server mole@127.0.0.1:22122 -key test-env/ssh-server/keys/key
+$ mole -insecure -local :21112 -local :21113 -remote 192.168.33.11:80 -remote 192.168.33.11:8080 -server mole@127.0.0.1:22122 -key test-env/ssh-server/keys/key -keep-alive-interval 2s
 INFO[0000] tunnel is ready                               local="127.0.0.1:21113" remote="192.168.33.11:8080"
 INFO[0000] tunnel is ready                               local="127.0.0.1:21112" remote="192.168.33.11:80"
 $ curl 127.0.0.1:21112

--- a/test-env/ssh-server/sshd_config
+++ b/test-env/ssh-server/sshd_config
@@ -7,3 +7,5 @@ AuthorizedKeysFile	.ssh/authorized_keys
 SyslogFacility AUTH
 LogLevel INFO
 AllowAgentForwarding yes
+ClientAliveInterval 3
+ClientAliveCountMax 0

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -349,6 +349,7 @@ func prepareTunnel(t *testing.T, remotes int, insecure bool) *Tunnel {
 	}
 
 	tun := &Tunnel{server: srv, channels: sshChannels, done: make(chan error), Ready: make(chan bool, 1)}
+	tun.KeepAliveInterval = 10 * time.Second
 
 	go func(t *testing.T, tun *Tunnel) {
 		err := tun.Start()


### PR DESCRIPTION
This change adds a mechanism to keep idle tunnels active even if the ssh
server is configured to end any connections that is idle for a period of
time by sending a global ssh request with no data.

Refers-to: #24, #26 