### PR TITLE
Make ssh server of test-env manageable

### DIFF
--- a/test-env/README.md
+++ b/test-env/README.md
@@ -98,6 +98,12 @@ $ curl 127.0.0.1:21113
 NOTE: If you're wondering about the smile face, that is the response from both 
 http servers.
 
+## How to manage the ssh server instance
+
+```sh
+$ docker exec -ti mole_ssh supervisorctl <stop|start|restart> sshd
+```
+
 ## Packet Analisys
 
 If you need to analyze the traffic going through the tunnel, the test

--- a/test-env/ssh-server/Dockerfile
+++ b/test-env/ssh-server/Dockerfile
@@ -1,6 +1,11 @@
 FROM alpine:3.6
 
-RUN apk update && apk add shadow libcap openssh tcpdump
+RUN apk update && apk add \
+      shadow \
+      libcap \
+      openssh \
+      tcpdump \
+      supervisor
 
 COPY sshd_config /etc/ssh/sshd_config
 COPY motd /etc/motd
@@ -13,4 +18,9 @@ RUN chgrp mole /usr/sbin/tcpdump && chmod 750 /usr/sbin/tcpdump && setcap cap_ne
 
 COPY authorized_keys /home/mole/.ssh/
 
-CMD /usr/sbin/sshd -D
+COPY supervisord.conf /etc/supervisord.conf
+RUN mkdir -p /var/log/supervisor
+
+#CMD /usr/sbin/sshd -D
+ENTRYPOINT ["/usr/bin/supervisord"]
+CMD ["-n", "-c", "/etc/supervisord.conf"]

--- a/test-env/ssh-server/supervisord.conf
+++ b/test-env/ssh-server/supervisord.conf
@@ -1,0 +1,24 @@
+[unix_http_server]
+file=/run/supervisord.sock                       ; path to your socket file
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log    ; supervisord log file
+logfile_maxbytes=50MB                           ; maximum size of logfile before rotation
+logfile_backups=10                              ; number of backed up logfiles
+loglevel=error                                  ; info, debug, warn, trace
+pidfile=/var/run/supervisord.pid                ; pidfile location
+nodaemon=false                                  ; run supervisord as a daemon
+minfds=1024                                     ; number of startup file descriptors
+minprocs=200                                    ; number of process descriptors
+user=root                                       ; default user
+childlogdir=/var/log/supervisor/                ; where child log files will live
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock         ; use a unix:// URL  for a unix socket
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+redirect_stderr=true


### PR DESCRIPTION
This change adds supervisor to the container that runs the ssh server, so
it can be restarted without a need to re-run the container.