### PR TITLE
Fix persistence of insecure mode

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,7 +30,7 @@ type App struct {
 	Detach            bool
 	Stop              string
 	AliasList         bool
-	InsecureMode      bool
+	Insecure          bool
 	KeepAliveInterval time.Duration
 }
 
@@ -58,7 +58,7 @@ func (c *App) Parse() error {
 	f.BoolVar(&c.Version, "version", false, "display the mole version")
 	f.BoolVar(&c.Detach, "detach", false, "(optional) run process in background")
 	f.StringVar(&c.Stop, "stop", "", "stop background process")
-	f.BoolVar(&c.InsecureMode, "insecure", false, "(optional) skip host key validation when connecting to ssh server")
+	f.BoolVar(&c.Insecure, "insecure", false, "(optional) skip host key validation when connecting to ssh server")
 	f.DurationVar(&c.KeepAliveInterval, "keep-alive-interval", 10*time.Second, "(optional) time interval for keep alive packets to be sent")
 
 	f.Parse(c.args[1:])
@@ -125,8 +125,8 @@ func (c *App) PrintUsage() {
 
 // String returns a string representation of an App.
 func (c App) String() string {
-	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t]",
-		c.Local, c.Remote, c.Server, c.Key, c.Verbose, c.Help, c.Version, c.Detach)
+	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t]",
+		c.Local, c.Remote, c.Server, c.Key, c.Verbose, c.Help, c.Version, c.Detach, c.Insecure)
 }
 
 // AddressInput holds information about a host

--- a/cmd/mole/alias.go
+++ b/cmd/mole/alias.go
@@ -26,14 +26,15 @@ func lsAliases() error {
 
 func app2alias(app cli.App) *storage.Alias {
 	return &storage.Alias{
-		Local:   app.Local.List(),
-		Remote:  app.Remote.List(),
-		Server:  app.Server.String(),
-		Key:     app.Key,
-		Verbose: app.Verbose,
-		Help:    app.Help,
-		Version: app.Version,
-		Detach:  app.Detach,
+		Local:    app.Local.List(),
+		Remote:   app.Remote.List(),
+		Server:   app.Server.String(),
+		Key:      app.Key,
+		Verbose:  app.Verbose,
+		Help:     app.Help,
+		Version:  app.Version,
+		Detach:   app.Detach,
+		Insecure: app.Insecure,
 	}
 }
 
@@ -62,14 +63,15 @@ func alias2app(t *storage.Alias) (*cli.App, error) {
 	server.Set(t.Server)
 
 	return &cli.App{
-		Command: "start",
-		Local:   lal,
-		Remote:  ral,
-		Server:  server,
-		Key:     t.Key,
-		Verbose: t.Verbose,
-		Help:    t.Help,
-		Version: t.Version,
-		Detach:  t.Detach,
+		Command:  "start",
+		Local:    lal,
+		Remote:   ral,
+		Server:   server,
+		Key:      t.Key,
+		Verbose:  t.Verbose,
+		Help:     t.Help,
+		Version:  t.Version,
+		Detach:   t.Detach,
+		Insecure: t.Insecure,
 	}, nil
 }

--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -240,7 +240,7 @@ func start(app *cli.App) error {
 		return err
 	}
 
-	s.Insecure = app.InsecureMode
+	s.Insecure = app.Insecure
 
 	s.Key.HandlePassphrase(func() ([]byte, error) {
 		fmt.Printf("The key provided is secured by a password. Please provide it below:\n")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -27,12 +27,13 @@ type Alias struct {
 	// since only a single value was supported before.
 	Remote interface{} `toml:"remote"`
 
-	Server  string `toml:"server"`
-	Key     string `toml:"key"`
-	Verbose bool   `toml:"verbose"`
-	Help    bool   `toml:"help"`
-	Version bool   `toml:"version"`
-	Detach  bool   `toml:"detach"`
+	Server   string `toml:"server"`
+	Key      string `toml:"key"`
+	Verbose  bool   `toml:"verbose"`
+	Help     bool   `toml:"help"`
+	Version  bool   `toml:"version"`
+	Detach   bool   `toml:"detach"`
+	Insecure bool   `toml:"insecure"`
 }
 
 func (t Alias) ReadLocal() ([]string, error) {
@@ -60,8 +61,8 @@ func readAddress(address interface{}) ([]string, error) {
 }
 
 func (t Alias) String() string {
-	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t]",
-		t.Local, t.Remote, t.Server, t.Key, t.Verbose, t.Help, t.Version, t.Detach)
+	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t]",
+		t.Local, t.Remote, t.Server, t.Key, t.Verbose, t.Help, t.Version, t.Detach, t.Insecure)
 }
 
 // Save stores Alias to the Store.


### PR DESCRIPTION
This change fixes a bug where creating an alias passing the -insecure
flag would not trigger the persistence of that option in
`$HOME/.mole.conf`.

Closes: #89