### PR TITLE
Add validation of -remote flag

### DIFF
--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -259,6 +259,12 @@ func start(app *cli.App) error {
 
 	remote := make([]string, len(app.Remote))
 	for i, r := range app.Remote {
+		if r.Port == "" {
+			err := fmt.Errorf("missing port in remote address: %s", r.String())
+			log.Error(err)
+			return err
+		}
+
 		remote[i] = r.String()
 	}
 


### PR DESCRIPTION
For https://github.com/davrodpin/mole/issues/86

Adds some basic validation of the remote address(es). The program will now exit with an error message if an address does not contain ":<port-number>".

Let me now if it was what you had in mind, or if I should change something.