### PR TITLE
Add retries if ssh conn shuts down

### DIFF
--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -280,6 +280,12 @@ func start(app *cli.App) error {
 		return err
 	}
 
+	//TODO need to find a way to require the attributes below to be always set
+	// since they are not optional (functionality will break if they are not
+	// set and CLI parsing is the one setting the default values).
+	// That could be done by make them required in the constructor's signature
+	t.ConnectionRetries = app.ConnectionRetries
+	t.WaitAndRetry = app.WaitAndRetry
 	t.KeepAliveInterval = app.KeepAliveInterval
 
 	if err = t.Start(); err != nil {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -108,12 +108,6 @@ type SSHChannel struct {
 	conn     net.Conn
 }
 
-func (ch *SSHChannel) Close() {
-	if ch.listener != nil {
-		ch.listener.Close()
-	}
-}
-
 func (ch SSHChannel) String() string {
 	return fmt.Sprintf("[local=%s, remote=%s]", ch.Local, ch.Remote)
 }
@@ -123,14 +117,25 @@ func (ch SSHChannel) String() string {
 type Tunnel struct {
 	// Ready tells when the Tunnel is ready to accept connections
 	Ready chan bool
+
 	// KeepAliveInterval is the time period used to send keep alive packets to
 	// the remote ssh server
 	KeepAliveInterval time.Duration
 
-	server   *Server
-	channels []*SSHChannel
-	done     chan error
-	client   *ssh.Client
+	// ConnectionRetries is the number os attempts to reconnect to the ssh server
+	// when the current connection fails
+	ConnectionRetries int
+
+	// WaitAndRetry is the time waited before trying to reconnect to the ssh
+	// server
+	WaitAndRetry time.Duration
+
+	server        *Server
+	channels      []*SSHChannel
+	done          chan error
+	client        *ssh.Client
+	stopKeepAlive chan bool
+	reconnect     chan error
 }
 
 // New creates a new instance of Tunnel.
@@ -143,85 +148,43 @@ func New(server *Server, channels []*SSHChannel) (*Tunnel, error) {
 	}
 
 	return &Tunnel{
-		Ready:    make(chan bool, 1),
-		channels: channels,
-		server:   server,
-		done:     make(chan error),
+		Ready:         make(chan bool, 1),
+		channels:      channels,
+		server:        server,
+		reconnect:     make(chan error, 1),
+		done:          make(chan error, 1),
+		stopKeepAlive: make(chan bool, 1),
 	}, nil
 }
 
 // Start creates the ssh tunnel and initialized all channels allowing data
 // exchange between local and remote enpoints.
 func (t *Tunnel) Start() error {
-	err := t.Listen()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		for _, ch := range t.channels {
-			ch.Close()
-		}
-	}()
-
 	log.Debugf("tunnel: %s", t)
 
-	//connecting to ssh server
-	err = t.dial()
-	if err != nil {
-		return err
-	}
+	t.connect()
 
-	wg := &sync.WaitGroup{}
-	wg.Add(len(t.channels))
+	for {
+		select {
+		case err := <-t.reconnect:
+			if err != nil {
+				log.WithError(err).Warnf("reconnecting to ssh server")
 
-	// wait for all ssh channels to be ready to accept connections then sends a
-	// single message signalling all tunnel are ready
-	go func(tunnel *Tunnel, waitgroup *sync.WaitGroup) {
-		waitgroup.Wait()
-		tunnel.Ready <- true
-	}(t, wg)
+				t.stopKeepAlive <- true
+				t.client.Close()
 
-	for _, ch := range t.channels {
-		go func(channel *SSHChannel, waitgroup *sync.WaitGroup) {
-			var err error
-			var once sync.Once
+				log.Debugf("restablishing the tunnel after disconnection: %s", t)
 
-			for {
-
-				once.Do(func() {
-					log.WithFields(log.Fields{
-						"local":  channel.Local,
-						"remote": channel.Remote,
-					}).Info("tunnel is ready")
-
-					waitgroup.Done()
-				})
-
-				channel.conn, err = channel.listener.Accept()
-				if err != nil {
-					t.done <- fmt.Errorf("error while establishing new connection: %v", err)
-					return
-				}
-
-				log.WithFields(log.Fields{
-					"address": channel.conn.RemoteAddr(),
-				}).Debug("new connection")
-
-				err = t.startChannel(channel)
-				if err != nil {
-					t.done <- err
-					return
-				}
+				t.connect()
 			}
-		}(ch, wg)
-	}
+		case err := <-t.done:
+			if t.client != nil {
+				t.stopKeepAlive <- true
+				t.client.Close()
+			}
 
-	select {
-	case err = <-t.done:
-		if t.client != nil {
-			t.client.Conn.Close()
+			return err
 		}
-		return err
 	}
 }
 
@@ -235,7 +198,7 @@ func (t *Tunnel) Listen() error {
 			}
 
 			ch.listener = l
-			ch.Local = l.Addr().String()
+			ch.Local = l.Addr().String() // update the value with assigned port is the given value is :0
 		}
 	}
 
@@ -243,8 +206,19 @@ func (t *Tunnel) Listen() error {
 }
 
 func (t *Tunnel) startChannel(channel *SSHChannel) error {
+	var err error
+
+	channel.conn, err = channel.listener.Accept()
+	if err != nil {
+		return fmt.Errorf("error while establishing local connection: %v", err)
+	}
+
+	log.WithFields(log.Fields{
+		"channel": channel,
+	}).Debug("local connection established")
+
 	if t.client == nil {
-		return fmt.Errorf("new channel can't be established: missing connection to the ssh server")
+		return fmt.Errorf("tunnel channel can't be established: missing connection to the ssh server")
 	}
 
 	remoteConn, err := t.client.Dial("tcp", channel.Remote)
@@ -256,9 +230,9 @@ func (t *Tunnel) startChannel(channel *SSHChannel) error {
 	go copyConn(remoteConn, channel.conn)
 
 	log.WithFields(log.Fields{
-		"remote": channel.Remote,
-		"server": t.server,
-	}).Debug("new connection established to remote")
+		"channel": channel,
+		"server":  t.server,
+	}).Debug("tunnel channel has been established")
 
 	return nil
 }
@@ -275,7 +249,7 @@ func (t Tunnel) String() string {
 
 func (t *Tunnel) dial() error {
 	if t.client != nil {
-		return nil
+		t.client.Close()
 	}
 
 	c, err := sshClientConfig(*t.server)
@@ -283,22 +257,107 @@ func (t *Tunnel) dial() error {
 		return fmt.Errorf("error generating ssh client config: %s", err)
 	}
 
-	t.client, err = ssh.Dial("tcp", t.server.Address, c)
-	if err != nil {
-		return fmt.Errorf("server dial error: %s", err)
+	retries := 0
+	for {
+		if t.ConnectionRetries > 0 && retries == t.ConnectionRetries {
+			log.WithFields(log.Fields{
+				"server":  t.server,
+				"retries": retries,
+			}).Error("maximum number of connection retries to the ssh server reached")
+
+			return fmt.Errorf("error while connecting to ssh server")
+		}
+
+		t.client, err = ssh.Dial("tcp", t.server.Address, c)
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"server":  t.server,
+				"retries": retries,
+			}).Debugf("error while connecting to ssh server")
+
+			if t.ConnectionRetries < 0 {
+				break
+			}
+
+			retries = retries + 1
+
+			time.Sleep(t.WaitAndRetry)
+			continue
+		}
+
+		break
 	}
 
 	go t.keepAlive()
 
+	if t.ConnectionRetries > 0 {
+		go t.waitAndReconnect()
+	}
+
 	log.WithFields(log.Fields{
 		"server": t.server,
-	}).Debug("new connection established to server")
+	}).Debug("connection to the ssh server is established")
 
 	return nil
 }
 
+func (t *Tunnel) waitAndReconnect() {
+	t.reconnect <- t.client.Wait()
+}
+
+func (t *Tunnel) connect() {
+	err := t.Listen()
+	if err != nil {
+		t.done <- err
+		return
+	}
+
+	err = t.dial()
+	if err != nil {
+		t.done <- err
+		return
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(t.channels))
+
+	// wait for all ssh channels to be ready to accept connections then sends a
+	// single message signalling all tunnels are ready
+	go func(tunnel *Tunnel, waitgroup *sync.WaitGroup) {
+		waitgroup.Wait()
+		t.Ready <- true
+	}(t, wg)
+
+	for _, ch := range t.channels {
+		go func(channel *SSHChannel, waitgroup *sync.WaitGroup) {
+			var err error
+			var once sync.Once
+
+			for {
+				once.Do(func() {
+					log.WithFields(log.Fields{
+						"local":  channel.Local,
+						"remote": channel.Remote,
+					}).Info("tunnel channel is waiting for connection")
+
+					waitgroup.Done()
+				})
+
+				err = t.startChannel(channel)
+				if err != nil {
+					t.done <- err
+					return
+				}
+			}
+		}(ch, wg)
+	}
+
+}
+
 func (t *Tunnel) keepAlive() {
 	ticker := time.NewTicker(t.KeepAliveInterval)
+
+	log.Debug("start sending keep alive packets")
 
 	for {
 		select {
@@ -307,6 +366,9 @@ func (t *Tunnel) keepAlive() {
 			if err != nil {
 				log.Warnf("error sending keep-alive request to ssh server: %v", err)
 			}
+		case <-t.stopKeepAlive:
+			log.Debug("stop sending keep alive packets")
+			return
 		}
 	}
 }


### PR DESCRIPTION
This change improves the resilience of mole by adding a connection retry
mechanism when the ssh connection is closed by any unexpected reason.

The number of retries and the wait time between retries are configurable
through the `-connection-retries` and `-retry-wait` flags.

Closes: #24