### PR TITLE
Fix README.md message about using go modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information about installation, usage, examples and specific use cases,
 ### Build and Install from Source
 
 * [Go 1.13+](https://golang.org/dl/) is required
-* Mole uses [Go Modules](https://blog.golang.org/using-go-modules) to manage its dependencies, so remember to clone the project outside `GOPATH` and unset it.
+* Mole uses [Go Modules](https://blog.golang.org/using-go-modules) to manage its dependencies.
 
 ```sh
 $ go build github.com/davrodpin/mole/cmd/mole


### PR DESCRIPTION
Since the minimal version of this project is now Go 1.13, the project can now be imported in the GOPATH and still use the go modules to manage it's dependency,even if the environment variable GO111MODULE=auto (which is the default), as stated in https://golang.org/doc/go1.13#modules

Signed-off-by: Ricardo Seriani <ricardo.seriani@gmail.com>