### PR TITLE
ssh-agent support

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -36,6 +36,7 @@ type App struct {
 	Timeout           time.Duration
 	ConnectionRetries int
 	WaitAndRetry      time.Duration
+	SSHAgent          string
 }
 
 // New creates a new instance of App.
@@ -67,6 +68,7 @@ func (c *App) Parse() error {
 	f.DurationVarP(&c.Timeout, "timeout", "t", 3*time.Second, "(optional) ssh server connection timeout")
 	f.IntVarP(&c.ConnectionRetries, "connection-retries", "R", 3, "(optional) maximum number of connection retries to the ssh server. Provide 0 if mole should never give up or negative number to disable retries")
 	f.DurationVarP(&c.WaitAndRetry, "retry-wait", "w", 3*time.Second, "(optional) time to wait before trying to reconnect to ssh server")
+	f.StringVarP(&c.SSHAgent, "ssh-agent", "A", "", "(optional) unix socket to communicate with an ssh agent")
 
 	f.Parse(c.args[1:])
 
@@ -121,8 +123,8 @@ func (c App) Validate() error {
 // use the tool.
 func (c *App) PrintUsage() {
 	fmt.Fprintf(os.Stderr, "%s\n\n", `usage:
-	mole [--verbose] [--insecure] [--detach] (--local [<host>]:<port>)... (--remote [<host>]:<port>)... --server [<user>@]<host>[:<port>] [--key <key_path>] [--keep-alive-interval <time_interval>] [--connection-retries <retries>] [--retry-wait <time>]
-	mole --alias <alias_name> [--verbose] (--local [<host>]:<port>)... (--remote [<host>]:<port>)... --server [<user>@]<host>[:<port>] [--key <key_path>] [--keep-alive-interval <time_interval>] [--connection-retries <retries>] [--retry-wait <time>]
+	mole [--verbose] [--insecure] [--detach] (--local [<host>]:<port>)... (--remote [<host>]:<port>)... --server [<user>@]<host>[:<port>] [--key <key_path>] [--keep-alive-interval <time_interval>] [--connection-retries <retries>] [--retry-wait <time>] [--ssh-agent <socket_path>]
+	mole --alias <alias_name> [--verbose] (--local [<host>]:<port>)... (--remote [<host>]:<port>)... --server [<user>@]<host>[:<port>] [--key <key_path>] [--keep-alive-interval <time_interval>] [--connection-retries <retries>] [--retry-wait <time>] [--ssh-agent <socket_path>]
 	mole --alias <alias_name> --delete
 	mole --start <alias_name>
 	mole --help
@@ -132,8 +134,8 @@ func (c *App) PrintUsage() {
 
 // String returns a string representation of an App.
 func (c App) String() string {
-	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t, keep-alive-interval=%v, timeout=%v, connection-retries=%d, retry-wait=%s]",
-		c.Local, c.Remote, c.Server, c.Key, c.Verbose, c.Help, c.Version, c.Detach, c.Insecure, c.KeepAliveInterval, c.Timeout, c.ConnectionRetries, c.WaitAndRetry)
+	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t, keep-alive-interval=%v, timeout=%v, connection-retries=%d, retry-wait=%s, ssh-agent=%s]",
+		c.Local, c.Remote, c.Server, c.Key, c.Verbose, c.Help, c.Version, c.Detach, c.Insecure, c.KeepAliveInterval, c.Timeout, c.ConnectionRetries, c.WaitAndRetry, c.SSHAgent)
 }
 
 // AddressInput holds information about a host

--- a/cmd/mole/alias.go
+++ b/cmd/mole/alias.go
@@ -37,6 +37,7 @@ func app2alias(app cli.App) *storage.Alias {
 		Insecure:          app.Insecure,
 		KeepAliveInterval: app.KeepAliveInterval,
 		Timeout:           app.Timeout,
+		SSHAgent:          app.SSHAgent,
 	}
 }
 
@@ -77,5 +78,6 @@ func alias2app(t *storage.Alias) (*cli.App, error) {
 		Insecure:          t.Insecure,
 		KeepAliveInterval: t.KeepAliveInterval,
 		Timeout:           t.Timeout,
+		SSHAgent:          t.SSHAgent,
 	}, nil
 }

--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -242,6 +242,7 @@ func start(app *cli.App) error {
 
 	s.Insecure = app.Insecure
 	s.Timeout = app.Timeout
+	s.SSHAgent = app.SSHAgent
 
 	s.Key.HandlePassphrase(func() ([]byte, error) {
 		fmt.Printf("The key provided is secured by a password. Please provide it below:\n")

--- a/cmd/mole/main.go
+++ b/cmd/mole/main.go
@@ -233,7 +233,7 @@ func start(app *cli.App) error {
 		"options": app.String(),
 	}).Debug("cli options")
 
-	s, err := tunnel.NewServer(app.Server.User, app.Server.Address(), app.Key)
+	s, err := tunnel.NewServer(app.Server.User, app.Server.Address(), app.Key, app.SSHAgent)
 	if err != nil {
 		log.Errorf("error processing server options: %v\n", err)
 
@@ -242,7 +242,6 @@ func start(app *cli.App) error {
 
 	s.Insecure = app.Insecure
 	s.Timeout = app.Timeout
-	s.SSHAgent = app.SSHAgent
 
 	s.Key.HandlePassphrase(func() ([]byte, error) {
 		fmt.Printf("The key provided is secured by a password. Please provide it below:\n")

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc h1:c0o/qxkaO2LF5t6fQrT4b5hzyggAkLLlCUjqfRxd8Q4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -37,6 +37,7 @@ type Alias struct {
 	Insecure          bool          `toml:"insecure"`
 	KeepAliveInterval time.Duration `toml:"keep-alive-interval"`
 	Timeout           time.Duration `toml:"timeout"`
+	SSHAgent          string        `toml:"ssh-agent"`
 }
 
 func (t Alias) ReadLocal() ([]string, error) {
@@ -64,8 +65,8 @@ func readAddress(address interface{}) ([]string, error) {
 }
 
 func (t Alias) String() string {
-	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t, ka-interval=%v, timeout=%v]",
-		t.Local, t.Remote, t.Server, t.Key, t.Verbose, t.Help, t.Version, t.Detach, t.Insecure, t.KeepAliveInterval, t.Timeout)
+	return fmt.Sprintf("[local=%s, remote=%s, server=%s, key=%s, verbose=%t, help=%t, version=%t, detach=%t, insecure=%t, ka-interval=%v, timeout=%v, ssh-agent=%s]",
+		t.Local, t.Remote, t.Server, t.Key, t.Verbose, t.Help, t.Version, t.Detach, t.Insecure, t.KeepAliveInterval, t.Timeout, t.SSHAgent)
 }
 
 // Save stores Alias to the Store.

--- a/tunnel/config.go
+++ b/tunnel/config.go
@@ -69,12 +69,18 @@ func (r SSHConfigFile) Get(host string) *SSHHost {
 
 	key := r.getKey(host)
 
+	identityAgent, err := r.sshConfig.Get(host, "IdentityAgent")
+	if err != nil {
+		identityAgent = ""
+	}
+
 	return &SSHHost{
-		Hostname:     hostname,
-		Port:         port,
-		User:         user,
-		Key:          key,
-		LocalForward: localForward,
+		Hostname:      hostname,
+		Port:          port,
+		User:          user,
+		Key:           key,
+		IdentityAgent: identityAgent,
+		LocalForward:  localForward,
 	}
 }
 
@@ -140,16 +146,17 @@ func (r SSHConfigFile) getKey(host string) string {
 
 // SSHHost represents a host configuration extracted from a ssh config file.
 type SSHHost struct {
-	Hostname     string
-	Port         string
-	User         string
-	Key          string
-	LocalForward *LocalForward
+	Hostname      string
+	Port          string
+	User          string
+	Key           string
+	IdentityAgent string
+	LocalForward  *LocalForward
 }
 
 // String returns a string representation of a SSHHost.
 func (h SSHHost) String() string {
-	return fmt.Sprintf("[hostname=%s, port=%s, user=%s, key=%s, local_forward=%s]", h.Hostname, h.Port, h.User, h.Key, h.LocalForward)
+	return fmt.Sprintf("[hostname=%s, port=%s, user=%s, key=%s, identity_agent=%s, local_forward=%s]", h.Hostname, h.Port, h.User, h.Key, h.IdentityAgent, h.LocalForward)
 }
 
 // LocalForward represents a LocalForward configuration for SSHHost.

--- a/tunnel/example_test.go
+++ b/tunnel/example_test.go
@@ -15,7 +15,7 @@ func Example() {
 
 	// Initialize the SSH Server configuration providing all values so
 	// tunnel.NewServer will not try to lookup any value using $HOME/.ssh/config
-	server, err := tunnel.NewServer("user", "172.17.0.20:2222", "/home/user/.ssh/key")
+	server, err := tunnel.NewServer("user", "172.17.0.20:2222", "/home/user/.ssh/key", "")
 	if err != nil {
 		log.Fatalf("error processing server options: %v\n", err)
 	}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -95,7 +95,7 @@ func TestServerOptions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		s, err := NewServer(test.user, test.address, test.key)
+		s, err := NewServer(test.user, test.address, test.key, "")
 		if err != nil {
 			if test.expectedError != nil {
 				if test.expectedError.Error() != err.Error() {
@@ -365,7 +365,7 @@ func prepareTunnel(remotes int, insecure bool, sshConnectionRetries int) (tun *T
 		return
 	}
 
-	srv, _ := NewServer("mole", ssh.Addr().String(), "")
+	srv, _ := NewServer("mole", ssh.Addr().String(), "", "")
 
 	srv.Insecure = insecure
 


### PR DESCRIPTION
An ssh-agent started in the traditional way (eval $(ssh-agent)) sets an
environment variable SSH_AUTH_SOCK which points to a unix socket that
the agent listens to. If that environment variable is set add the public
keys in the ssh agent to the list of keys used during authentication.

closes #87 