### PR TITLE
Add arm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ endif
 	cd bin && tar c mole | gzip > mole$(version).darwin-amd64.tar.gz && rm mole && cd -
 	GOOS=linux GOARCH=amd64 go build -o bin/mole -ldflags "$(LDFLAGS)" github.com/davrodpin/mole/cmd/mole
 	cd bin && tar c mole | gzip > mole$(version).linux-amd64.tar.gz && rm mole && cd -
+	GOOS=linux GOARCH=arm go build -o bin/mole -ldflags "$(LDFLAGS)" github.com/davrodpin/mole/cmd/mole
+	cd bin && tar c mole | gzip > mole$(version).linux-arm.tar.gz && rm mole && cd -
+	GOOS=linux GOARCH=arm64 go build -o bin/mole -ldflags "$(LDFLAGS)" github.com/davrodpin/mole/cmd/mole
+	cd bin && tar c mole | gzip > mole$(version).linux-arm64.tar.gz && rm mole && cd -
 	GOOS=windows GOARCH=amd64 go build -o bin/mole.exe -ldflags "$(LDFLAGS)" github.com/davrodpin/mole/cmd/mole
 	cd bin && zip mole$(version).windows-amd64.zip mole.exe && rm -f mole.exe && cd -
 


### PR DESCRIPTION
I'm not sure what your process is for uploading releases to GH, but this patch adds cross building for arm arch via the go toolchain to your `bin` target.