### PR TITLE
Update CI docker image

### DIFF
--- a/.github/actions/check/Dockerfile
+++ b/.github/actions/check/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1
+FROM golang:1.14.7
 
 LABEL "com.github.actions.name"="action-check"
 LABEL "com.github.actions.description"="Code quality check for Mole"


### PR DESCRIPTION
This change updates the docker image used for continuous integration, updating
the Go version to 1.14.