### PR TITLE
Add flags to "start alias" command

### DIFF
--- a/alias/alias.go
+++ b/alias/alias.go
@@ -167,6 +167,13 @@ func (a Alias) ParseTunnelFlags() (*TunnelFlags, error) {
 	return tf, nil
 }
 
+// Merge overwrites certain Alias attributes based on the given TunnelFlags.
+func (a *Alias) Merge(tunnelFlags *TunnelFlags) {
+	a.Verbose = tunnelFlags.Verbose
+	a.Insecure = tunnelFlags.Insecure
+	a.Detach = tunnelFlags.Detach
+}
+
 func (a Alias) String() string {
 	return fmt.Sprintf("[verbose: %t, insecure: %t, detach: %t, source: %s, destination: %s, server: %s, key: %s, keep-alive-interval: %s, connection-retries: %d, wait-and-retry: %s, ssh-agent: %s, timeout: %s]",
 		a.Verbose,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,23 +63,23 @@ provide 0 to never give up or a negative number to disable`)
 	return nil
 }
 
-func start(alias string, tunnelFlags *alias.TunnelFlags) {
+func start(id string, tunnelFlags *alias.TunnelFlags) {
 	if tunnelFlags.Detach {
 		var err error
 
-		if alias == "" {
+		if id == "" {
 			u, err := uuid.NewV4()
 			if err != nil {
 				log.Errorf("error could not generate uuid: %v", err)
 				os.Exit(1)
 			}
-			alias = u.String()[:8]
+			id = u.String()[:8]
 		}
 
-		err = startDaemonProcess(alias)
+		err = startDaemonProcess(id)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"alias": alias,
+				"id": id,
 			}).Errorf("error starting ssh tunnel: %v", err)
 			os.Exit(1)
 		}
@@ -204,12 +204,7 @@ func startDaemonProcess(aliasName string) error {
 	return nil
 }
 
-func startWithAlias(aliasName string) error {
-	a, err := alias.Get(aliasName)
-	if err != nil {
-		return err
-	}
-
+func startFromAlias(aliasName string, a *alias.Alias) error {
 	f, err := a.ParseTunnelFlags()
 	if err != nil {
 		return err

--- a/cmd/start_alias.go
+++ b/cmd/start_alias.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/davrodpin/mole/alias"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,11 @@ import (
 var startAliasCmd = &cobra.Command{
 	Use:   "alias [name]",
 	Short: "Starts a ssh tunnel by alias",
-	Long:  "Starts a ssh tunnel by alias",
+	Long: `Starts a ssh tunnel by alias
+
+The flags provided through this command can be used to override the one with the
+same name stored in the alias.
+`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("alias name not provided")
@@ -22,14 +27,28 @@ var startAliasCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, arg []string) {
-		err := startWithAlias(aliasName)
+		var err error
+
+		a, err := alias.Get(aliasName)
 		if err != nil {
-			log.Errorf("failed to start tunnel: %v", err)
+			log.WithError(err).Errorf("failed to start tunnel from alias %s", aliasName)
+			os.Exit(1)
+		}
+
+		a.Merge(tunnelFlags)
+
+		err = startFromAlias(aliasName, a)
+		if err != nil {
+			log.WithError(err).Errorf("failed to start tunnel from alias %s", aliasName)
 			os.Exit(1)
 		}
 	},
 }
 
 func init() {
+	startAliasCmd.Flags().BoolVarP(&tunnelFlags.Verbose, "verbose", "v", false, "increase log verbosity")
+	startAliasCmd.Flags().BoolVarP(&tunnelFlags.Insecure, "insecure", "i", false, "skip host key validation when connecting to ssh server")
+	startAliasCmd.Flags().BoolVarP(&tunnelFlags.Detach, "detach", "x", false, "run process in background")
+
 	startCmd.AddCommand(startAliasCmd)
 }

--- a/cmd/start_local.go
+++ b/cmd/start_local.go
@@ -29,7 +29,9 @@ Destination endpoints are adrresess that can be reached from the jump server.
 }
 
 func init() {
-	err := bindFlags(tunnelFlags, localCmd)
+	var err error
+
+	err = bindFlags(tunnelFlags, localCmd)
 	if err != nil {
 		log.WithError(err).Error("error parsing command line arguments")
 		os.Exit(1)


### PR DESCRIPTION
This change allows the user to provide certain flags to `start alias`
command. The flags provided through CLI will override the ones stored in
the alias configuration.

Fixes #119.