### PR TITLE
Remove duplication of log and memguard init.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,10 +29,6 @@ var (
 
 // Execute executes the root command
 func Execute() error {
-	// memguard is used to securely keep sensitive information in memory.
-	// This call makes sure all data will be destroy when the program exits.
-	defer memguard.Purge()
-
 	log.SetOutput(os.Stdout)
 
 	return rootCmd.Execute()
@@ -64,6 +60,10 @@ provide 0 to never give up or a negative number to disable`)
 }
 
 func start(id string, tunnelFlags *alias.TunnelFlags) {
+	// memguard is used to securely keep sensitive information in memory.
+	// This call makes sure all data will be destroy when the program exits.
+	defer memguard.Purge()
+
 	if tunnelFlags.Detach {
 		var err error
 

--- a/main.go
+++ b/main.go
@@ -4,18 +4,9 @@ import (
 	"os"
 
 	"github.com/davrodpin/mole/cmd"
-
-	"github.com/awnumar/memguard"
-	log "github.com/sirupsen/logrus"
 )
 
 func main() {
-	// memguard is used to securely keep sensitive information in memory.
-	// This call makes sure all data will be destroy when the program exits.
-	defer memguard.Purge()
-
-	log.SetOutput(os.Stdout)
-
 	err := cmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
This change makes the log module configuration and memguard destrutor
call to be initialized only once and in the right place.