### PR TITLE
Fix load value of certain flags from alias

### DIFF
--- a/alias/alias.go
+++ b/alias/alias.go
@@ -47,6 +47,9 @@ type TunnelFlags struct {
 	WaitAndRetry      time.Duration
 	SshAgent          string
 	Timeout           time.Duration
+
+	// GivenFlags contains list of all flags that were given by the user.
+	GivenFlags []string
 }
 
 // ParseAlias translates a TunnelFlags object to an Alias object
@@ -67,6 +70,17 @@ func (tf TunnelFlags) ParseAlias(name string) *Alias {
 		SshAgent:          tf.SshAgent,
 		Timeout:           tf.Timeout.String(),
 	}
+}
+
+// FlagGiven tells if a specific flag was given by the user through CLI.
+func (tf TunnelFlags) FlagGiven(flag string) bool {
+	for _, f := range tf.GivenFlags {
+		if flag == f {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (tf TunnelFlags) String() string {
@@ -169,9 +183,17 @@ func (a Alias) ParseTunnelFlags() (*TunnelFlags, error) {
 
 // Merge overwrites certain Alias attributes based on the given TunnelFlags.
 func (a *Alias) Merge(tunnelFlags *TunnelFlags) {
-	a.Verbose = tunnelFlags.Verbose
-	a.Insecure = tunnelFlags.Insecure
-	a.Detach = tunnelFlags.Detach
+	if tunnelFlags.FlagGiven("verbose") {
+		a.Verbose = tunnelFlags.Verbose
+	}
+
+	if tunnelFlags.FlagGiven("insecure") {
+		a.Insecure = tunnelFlags.Insecure
+	}
+
+	if tunnelFlags.FlagGiven("detach") {
+		a.Detach = tunnelFlags.Detach
+	}
 }
 
 func (a Alias) String() string {

--- a/alias/alias_test.go
+++ b/alias/alias_test.go
@@ -248,6 +248,7 @@ func TestAliasMerge(t *testing.T) {
 	tests := []struct {
 		alias       alias.Alias
 		tunnelFlags *alias.TunnelFlags
+		expected    alias.Alias
 	}{
 		{
 			alias.Alias{
@@ -274,6 +275,45 @@ func TestAliasMerge(t *testing.T) {
 				Key:               "path/to/key/2",
 				KeepAliveInterval: keepAliveInterval,
 				ConnectionRetries: 10,
+				GivenFlags:        []string{"verbose", "insecure", "detach"},
+			},
+			alias.Alias{
+				Verbose:  true,
+				Insecure: true,
+				Detach:   true,
+			},
+		},
+		{
+			alias.Alias{
+				Verbose:           true,
+				Insecure:          true,
+				Detach:            true,
+				Source:            []string{"127.0.0.1:80"},
+				Destination:       []string{"172.17.0.100:8080"},
+				Server:            "user@example.com:22",
+				Key:               "path/to/key/1",
+				KeepAliveInterval: "3s",
+				ConnectionRetries: 3,
+				WaitAndRetry:      "10s",
+				SshAgent:          "path/to/sshagent",
+				Timeout:           "3s",
+			},
+			&alias.TunnelFlags{
+				Verbose:           false,
+				Insecure:          false,
+				Detach:            false,
+				Source:            alias.AddressInputList([]alias.AddressInput{alias.AddressInput{Host: "127.0.0.1", Port: "80"}}),
+				Destination:       alias.AddressInputList([]alias.AddressInput{alias.AddressInput{Host: "172.17.0.100", Port: "8080"}}),
+				Server:            alias.AddressInput{Host: "acme.com", Port: "22"},
+				Key:               "path/to/key/2",
+				KeepAliveInterval: keepAliveInterval,
+				ConnectionRetries: 10,
+				GivenFlags:        []string{},
+			},
+			alias.Alias{
+				Verbose:  true,
+				Insecure: true,
+				Detach:   true,
 			},
 		},
 	}
@@ -281,16 +321,16 @@ func TestAliasMerge(t *testing.T) {
 	for id, test := range tests {
 		test.alias.Merge(test.tunnelFlags)
 
-		if test.alias.Verbose != test.tunnelFlags.Verbose {
-			t.Errorf("alias verbose doesn't match on test %d: expected: %t, value: %t", id, test.tunnelFlags.Verbose, test.alias.Verbose)
+		if test.expected.Verbose != test.alias.Verbose {
+			t.Errorf("alias verbose doesn't match on test %d: expected: %t, value: %t", id, test.expected.Verbose, test.alias.Verbose)
 		}
 
-		if test.alias.Insecure != test.tunnelFlags.Insecure {
-			t.Errorf("alias insecure doesn't match on test %d: expected: %t, value: %t", id, test.tunnelFlags.Insecure, test.alias.Insecure)
+		if test.expected.Insecure != test.alias.Insecure {
+			t.Errorf("alias insecure doesn't match on test %d: expected: %t, value: %t", id, test.expected.Insecure, test.alias.Insecure)
 		}
 
-		if test.alias.Detach != test.tunnelFlags.Detach {
-			t.Errorf("alias detach doesn't match on test %d: expected: %t, value: %t", id, test.tunnelFlags.Detach, test.alias.Detach)
+		if test.expected.Detach != test.alias.Detach {
+			t.Errorf("alias detach doesn't match on test %d: expected: %t, value: %t", id, test.expected.Detach, test.alias.Detach)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	daemon "github.com/sevlyar/go-daemon"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -55,6 +56,10 @@ provide 0 to never give up or a negative number to disable`)
 	if err != nil {
 		return err
 	}
+
+	flag.Visit(func(f *flag.Flag) {
+		flags.GivenFlags = append(flags.GivenFlags, f.Name)
+	})
 
 	return nil
 }


### PR DESCRIPTION
This change fixes the issue with the `verbose`, `insecure` and
`detach` flags being saved with value true bue  not working when using the
`start alias` command.

Closes #127