### PR TITLE
SSH config file path flag parameter

### DIFF
--- a/alias/alias.go
+++ b/alias/alias.go
@@ -46,6 +46,7 @@ type TunnelFlags struct {
 	WaitAndRetry      time.Duration
 	SshAgent          string
 	Timeout           time.Duration
+	Config            string
 
 	// GivenFlags contains list of all flags that were given by the user.
 	GivenFlags []string
@@ -68,6 +69,7 @@ func (tf TunnelFlags) ParseAlias(name string) *Alias {
 		WaitAndRetry:      tf.WaitAndRetry.String(),
 		SshAgent:          tf.SshAgent,
 		Timeout:           tf.Timeout.String(),
+		Config:            tf.Config,
 	}
 }
 
@@ -115,6 +117,7 @@ type Alias struct {
 	WaitAndRetry      string   `toml:"wait-and-retry"`
 	SshAgent          string   `toml:"ssh-agent"`
 	Timeout           string   `toml:"timeout"`
+	Config            string   `toml:"config"`
 }
 
 // ParseTunnelFlags parses an Alias into a TunnelFlags

--- a/alias/alias.go
+++ b/alias/alias.go
@@ -130,6 +130,7 @@ func (a Alias) ParseTunnelFlags() (*TunnelFlags, error) {
 	tf.Verbose = a.Verbose
 	tf.Insecure = a.Insecure
 	tf.Detach = a.Detach
+	tf.Config = a.Config
 
 	srcl := AddressInputList{}
 	for _, src := range a.Source {

--- a/alias/alias_test.go
+++ b/alias/alias_test.go
@@ -31,6 +31,7 @@ func TestParseTunnelFlags(t *testing.T) {
 		waitAndRetry      string
 		sshAgent          string
 		timeout           string
+		config            string
 	}{
 		{
 			"local",
@@ -46,6 +47,7 @@ func TestParseTunnelFlags(t *testing.T) {
 			"5s",
 			"path/to/ssh/agent",
 			"1m0s",
+			"/home/user/.ssh/config",
 		},
 		{
 			"local",
@@ -61,6 +63,7 @@ func TestParseTunnelFlags(t *testing.T) {
 			"5s",
 			"path/to/ssh/agent",
 			"1m0s",
+			"/home/user/.ssh/config",
 		},
 	}
 
@@ -79,6 +82,7 @@ func TestParseTunnelFlags(t *testing.T) {
 			WaitAndRetry:      test.waitAndRetry,
 			SshAgent:          test.sshAgent,
 			Timeout:           test.timeout,
+			Config:            test.config,
 		}
 
 		tf, err := ai.ParseTunnelFlags()
@@ -100,6 +104,10 @@ func TestParseTunnelFlags(t *testing.T) {
 
 		if test.detach != tf.Detach {
 			t.Errorf("detach doesn't match on test %d: expected: %t, value: %t", id, test.detach, tf.Detach)
+		}
+
+		if test.config != tf.Config {
+			t.Errorf("config doesn't match on test %d: expected: %s, value: %s", id, test.config, tf.Config)
 		}
 
 		for i, tsrc := range test.source {
@@ -264,6 +272,7 @@ func TestAliasMerge(t *testing.T) {
 				WaitAndRetry:      "10s",
 				SshAgent:          "path/to/sshagent",
 				Timeout:           "3s",
+				Config:            "/home/user/.ssh/config",
 			},
 			&alias.TunnelFlags{
 				Verbose:           true,
@@ -276,6 +285,7 @@ func TestAliasMerge(t *testing.T) {
 				KeepAliveInterval: keepAliveInterval,
 				ConnectionRetries: 10,
 				GivenFlags:        []string{"verbose", "insecure", "detach"},
+				Config:            "/home/user/.ssh/config",
 			},
 			alias.Alias{
 				Verbose:  true,
@@ -297,6 +307,7 @@ func TestAliasMerge(t *testing.T) {
 				WaitAndRetry:      "10s",
 				SshAgent:          "path/to/sshagent",
 				Timeout:           "3s",
+				Config:            "/home/user/.ssh/config",
 			},
 			&alias.TunnelFlags{
 				Verbose:           false,
@@ -309,6 +320,7 @@ func TestAliasMerge(t *testing.T) {
 				KeepAliveInterval: keepAliveInterval,
 				ConnectionRetries: 10,
 				GivenFlags:        []string{},
+				Config:            "/home/user/.ssh/config",
 			},
 			alias.Alias{
 				Verbose:  true,
@@ -355,6 +367,7 @@ func TestParseAlias(t *testing.T) {
 		WaitAndRetry:      war,
 		SshAgent:          "path/to/sshagent",
 		Timeout:           tim,
+		Config:            "/home/user/.ssh/config",
 	}
 
 	al := flags.ParseAlias("aliasName")
@@ -373,6 +386,10 @@ func TestParseAlias(t *testing.T) {
 
 	if flags.Detach != al.Detach {
 		t.Errorf("detach does not match: expected: %t, value: %t", flags.Detach, al.Detach)
+	}
+
+	if flags.Config != al.Config {
+		t.Errorf("config does not match: expected: %s, value: %s", flags.Config, al.Config)
 	}
 
 	if !reflect.DeepEqual(flags.Source.List(), al.Source) {
@@ -429,6 +446,7 @@ func addAlias() (*alias.Alias, error) {
 		WaitAndRetry:      "10s",
 		SshAgent:          "path/to/agent",
 		Timeout:           "1m",
+		Config:            "/home/user/.ssh/config",
 	}
 
 	err := alias.Add(a)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ provide 0 to never give up or a negative number to disable`)
 	cmd.Flags().DurationVarP(&flags.WaitAndRetry, "retry-wait", "w", 3*time.Second, "time to wait before trying to reconnect to ssh server")
 	cmd.Flags().StringVarP(&flags.SshAgent, "ssh-agent", "A", "", "unix socket to communicate with a ssh agent")
 	cmd.Flags().DurationVarP(&flags.Timeout, "timeout", "t", 3*time.Second, "ssh server connection timeout")
-	cmd.Flags().StringVarP(&flags.Config, "config", "c", "", "set config file path")
+	cmd.Flags().StringVarP(&flags.Config, "config", "c", "$HOME/.ssh/config", "set config file path")
 
 	err := cmd.MarkFlagRequired("server")
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,7 +133,7 @@ func start(id string, tunnelFlags *alias.TunnelFlags) {
 		destination[i] = r.String()
 	}
 
-	t, err := tunnel.New(tunnelFlags.TunnelType, s, source, destination)
+	t, err := tunnel.New(tunnelFlags.TunnelType, s, source, destination, tunnelFlags.Config)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ provide 0 to never give up or a negative number to disable`)
 	cmd.Flags().DurationVarP(&flags.WaitAndRetry, "retry-wait", "w", 3*time.Second, "time to wait before trying to reconnect to ssh server")
 	cmd.Flags().StringVarP(&flags.SshAgent, "ssh-agent", "A", "", "unix socket to communicate with a ssh agent")
 	cmd.Flags().DurationVarP(&flags.Timeout, "timeout", "t", 3*time.Second, "ssh server connection timeout")
+	cmd.Flags().StringVarP(&flags.Config, "config", "c", "", "set config file path")
 
 	err := cmd.MarkFlagRequired("server")
 	if err != nil {
@@ -92,7 +93,7 @@ func start(id string, tunnelFlags *alias.TunnelFlags) {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	s, err := tunnel.NewServer(tunnelFlags.Server.User, tunnelFlags.Server.Address(), tunnelFlags.Key, tunnelFlags.SshAgent)
+	s, err := tunnel.NewServer(tunnelFlags.Server.User, tunnelFlags.Server.Address(), tunnelFlags.Key, tunnelFlags.SshAgent, tunnelFlags.Config)
 	if err != nil {
 		log.Errorf("error processing server options: %v\n", err)
 		os.Exit(1)

--- a/tunnel/config.go
+++ b/tunnel/config.go
@@ -17,16 +17,9 @@ type SSHConfigFile struct {
 }
 
 // NewSSHConfigFile creates a new instance of SSHConfigFile based on the
-// ssh config file from $HOME/.ssh/config.
-func NewSSHConfigFile() (*SSHConfigFile, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-
-	configPath := filepath.Join(home, ".ssh", "config")
-
-	f, err := os.Open(filepath.Clean(configPath))
+// ssh config file from configPath
+func NewSSHConfigFile(configPath SSHConfigFilePath) (*SSHConfigFile, error) {
+	f, err := os.Open(filepath.Clean(string(configPath)))
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +139,31 @@ func (r SSHConfigFile) getKey(host string) string {
 	}
 
 	return ""
+}
+
+// SSHConfigFilePath is a path to the ssh config file
+type SSHConfigFilePath string
+
+// NewSSHConfigFilePath creates a new instance of SSHConfigFilePath
+// from customPath or fallback to NewDefaultSSHConfigFilePath
+func NewSSHConfigFilePath(customPath string) (SSHConfigFilePath, error) {
+	if customPath != "" {
+		return SSHConfigFilePath(customPath), nil
+	}
+
+	return NewDefaultSSHConfigFilePath()
+}
+
+// NewDefaultSSHConfigFilePath creates a new instance of SSHConfigFilePath from $HOME/.ssh/config
+func NewDefaultSSHConfigFilePath() (SSHConfigFilePath, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configPath := filepath.Join(home, ".ssh", "config")
+
+	return SSHConfigFilePath(configPath), nil
 }
 
 // SSHHost represents a host configuration extracted from a ssh config file.

--- a/tunnel/config.go
+++ b/tunnel/config.go
@@ -145,17 +145,12 @@ func (r SSHConfigFile) getKey(host string) string {
 type SSHConfigFilePath string
 
 // NewSSHConfigFilePath creates a new instance of SSHConfigFilePath
-// from customPath or fallback to NewDefaultSSHConfigFilePath
+// from customPath or fallback to $HOME/.ssh/config
 func NewSSHConfigFilePath(customPath string) (SSHConfigFilePath, error) {
 	if customPath != "" {
 		return SSHConfigFilePath(customPath), nil
 	}
 
-	return NewDefaultSSHConfigFilePath()
-}
-
-// NewDefaultSSHConfigFilePath creates a new instance of SSHConfigFilePath from $HOME/.ssh/config
-func NewDefaultSSHConfigFilePath() (SSHConfigFilePath, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/tunnel/example_test.go
+++ b/tunnel/example_test.go
@@ -16,7 +16,7 @@ func Example() {
 
 	// Initialize the SSH Server configuration providing all values so
 	// tunnel.NewServer will not try to lookup any value using $HOME/.ssh/config
-	server, err := tunnel.NewServer("user", "172.17.0.20:2222", "/home/user/.ssh/key", "")
+	server, err := tunnel.NewServer("user", "172.17.0.20:2222", "/home/user/.ssh/key", "", "/home/user/.ssh/config")
 	if err != nil {
 		log.Fatalf("error processing server options: %v\n", err)
 	}

--- a/tunnel/example_test.go
+++ b/tunnel/example_test.go
@@ -21,7 +21,7 @@ func Example() {
 		log.Fatalf("error processing server options: %v\n", err)
 	}
 
-	t, err := tunnel.New("local", server, sourceEndpoints, destinationEndpoints)
+	t, err := tunnel.New("local", server, sourceEndpoints, destinationEndpoints, "/home/user/.ssh/key")
 	if err != nil {
 		log.Fatalf("error creating tunnel: %v\n", err)
 	}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -40,7 +40,7 @@ type Server struct {
 // NewServer creates a new instance of Server using $HOME/.ssh/config to
 // resolve the missing connection attributes (e.g. user, hostname, port, key
 // and ssh agent) required to connect to the remote server, if any.
-func NewServer(user, address, key, sshAgent, config string) (*Server, error) {
+func NewServer(user, address, key, sshAgent, cfgPath string) (*Server, error) {
 	var host string
 	var hostname string
 	var port string
@@ -50,11 +50,6 @@ func NewServer(user, address, key, sshAgent, config string) (*Server, error) {
 		args := strings.Split(host, ":")
 		host = args[0]
 		port = args[1]
-	}
-
-	cfgPath, err := NewSSHConfigFilePath(config)
-	if err != nil {
-		return nil, fmt.Errorf("error building ssh configuration file path: %v", err)
 	}
 
 	c, err := NewSSHConfigFile(cfgPath)
@@ -548,11 +543,11 @@ func expandAddress(address string) string {
 	return address
 }
 
-func buildSSHChannels(serverName, channelType string, source, destination []string, config string) ([]*SSHChannel, error) {
+func buildSSHChannels(serverName, channelType string, source, destination []string, cfgPath string) ([]*SSHChannel, error) {
 	// if source and destination were not given, try to find the addresses from the
 	// SSH configuration file.
 	if len(source) == 0 && len(destination) == 0 {
-		f, err := getForward(channelType, serverName, config)
+		f, err := getForward(channelType, serverName, cfgPath)
 		if err != nil {
 			return nil, err
 		}
@@ -609,13 +604,8 @@ func buildSSHChannels(serverName, channelType string, source, destination []stri
 	return channels, nil
 }
 
-func getForward(channelType, serverName string, config string) (*ForwardConfig, error) {
+func getForward(channelType, serverName string, cfgPath string) (*ForwardConfig, error) {
 	var f *ForwardConfig
-
-	cfgPath, err := NewSSHConfigFilePath(config)
-	if err != nil {
-		return nil, fmt.Errorf("error building ssh configuration file path: %v", err)
-	}
 
 	cfg, err := NewSSHConfigFile(cfgPath)
 	if err != nil {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -206,11 +206,11 @@ type Tunnel struct {
 }
 
 // New creates a new instance of Tunnel.
-func New(tunnelType string, server *Server, source, destination []string) (*Tunnel, error) {
+func New(tunnelType string, server *Server, source, destination []string, config string) (*Tunnel, error) {
 	var channels []*SSHChannel
 	var err error
 
-	channels, err = buildSSHChannels(server.Name, tunnelType, source, destination)
+	channels, err = buildSSHChannels(server.Name, tunnelType, source, destination, config)
 	if err != nil {
 		return nil, err
 	}
@@ -548,11 +548,11 @@ func expandAddress(address string) string {
 	return address
 }
 
-func buildSSHChannels(serverName, channelType string, source, destination []string) ([]*SSHChannel, error) {
+func buildSSHChannels(serverName, channelType string, source, destination []string, config string) ([]*SSHChannel, error) {
 	// if source and destination were not given, try to find the addresses from the
 	// SSH configuration file.
 	if len(source) == 0 && len(destination) == 0 {
-		f, err := getForward(channelType, serverName)
+		f, err := getForward(channelType, serverName, config)
 		if err != nil {
 			return nil, err
 		}
@@ -609,10 +609,10 @@ func buildSSHChannels(serverName, channelType string, source, destination []stri
 	return channels, nil
 }
 
-func getForward(channelType, serverName string) (*ForwardConfig, error) {
+func getForward(channelType, serverName string, config string) (*ForwardConfig, error) {
 	var f *ForwardConfig
 
-	cfgPath, err := NewDefaultSSHConfigFilePath()
+	cfgPath, err := NewSSHConfigFilePath(config)
 	if err != nil {
 		return nil, fmt.Errorf("error building ssh configuration file path: %v", err)
 	}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -40,7 +40,7 @@ type Server struct {
 // NewServer creates a new instance of Server using $HOME/.ssh/config to
 // resolve the missing connection attributes (e.g. user, hostname, port, key
 // and ssh agent) required to connect to the remote server, if any.
-func NewServer(user, address, key, sshAgent string) (*Server, error) {
+func NewServer(user, address, key, sshAgent, config string) (*Server, error) {
 	var host string
 	var hostname string
 	var port string
@@ -52,7 +52,12 @@ func NewServer(user, address, key, sshAgent string) (*Server, error) {
 		port = args[1]
 	}
 
-	c, err := NewSSHConfigFile()
+	cfgPath, err := NewSSHConfigFilePath(config)
+	if err != nil {
+		return nil, fmt.Errorf("error building ssh configuration file path: %v", err)
+	}
+
+	c, err := NewSSHConfigFile(cfgPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("error accessing %s: %v", host, err)
@@ -607,7 +612,12 @@ func buildSSHChannels(serverName, channelType string, source, destination []stri
 func getForward(channelType, serverName string) (*ForwardConfig, error) {
 	var f *ForwardConfig
 
-	cfg, err := NewSSHConfigFile()
+	cfgPath, err := NewDefaultSSHConfigFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("error building ssh configuration file path: %v", err)
+	}
+
+	cfg, err := NewSSHConfigFile(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading ssh configuration file: %v", err)
 	}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -26,6 +26,7 @@ var keyPath string
 var encryptedKeyPath string
 var publicKeyPath string
 var knownHostsPath string
+var configPath string
 
 func TestServerOptions(t *testing.T) {
 	k1, _ := NewPemKey("testdata/.ssh/id_rsa", "")
@@ -292,6 +293,7 @@ func TestBuildSSHChannels(t *testing.T) {
 		serverName    string
 		source        []string
 		destination   []string
+		config        string
 		expected      int
 		expectedError error
 	}{
@@ -299,6 +301,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{":3360"},
 			destination:   []string{":3360"},
+			config:        "testdata/.ssh/config",
 			expected:      1,
 			expectedError: nil,
 		},
@@ -306,6 +309,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{":3360", ":8080"},
 			destination:   []string{":3360", ":8080"},
+			config:        "testdata/.ssh/config",
 			expected:      2,
 			expectedError: nil,
 		},
@@ -313,6 +317,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{},
 			destination:   []string{":3360"},
+			config:        "testdata/.ssh/config",
 			expected:      1,
 			expectedError: nil,
 		},
@@ -320,6 +325,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{":3360"},
 			destination:   []string{":3360", ":8080"},
+			config:        "testdata/.ssh/config",
 			expected:      2,
 			expectedError: nil,
 		},
@@ -327,6 +333,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "hostWithLocalForward",
 			source:        []string{},
 			destination:   []string{},
+			config:        "testdata/.ssh/config",
 			expected:      1,
 			expectedError: nil,
 		},
@@ -334,6 +341,7 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{":3360", ":8080"},
 			destination:   []string{":3360"},
+			config:        "testdata/.ssh/config",
 			expected:      1,
 			expectedError: nil,
 		},
@@ -341,13 +349,14 @@ func TestBuildSSHChannels(t *testing.T) {
 			serverName:    "test",
 			source:        []string{":3360"},
 			destination:   []string{},
+			config:        "testdata/.ssh/config",
 			expected:      0,
 			expectedError: fmt.Errorf(NoDestinationGiven),
 		},
 	}
 
 	for testId, test := range tests {
-		sshChannels, err := buildSSHChannels(test.serverName, "local", test.source, test.destination)
+		sshChannels, err := buildSSHChannels(test.serverName, "local", test.source, test.destination, test.config)
 		if err != nil {
 			if test.expectedError != nil {
 				if test.expectedError.Error() != err.Error() {
@@ -443,7 +452,7 @@ func prepareTunnel(config *tunnelConfig) (tun *Tunnel, ssh net.Listener, hss []*
 		hss = append(hss, hs)
 	}
 
-	tun, _ = New(config.TunnelType, srv, source, destination)
+	tun, _ = New(config.TunnelType, srv, source, destination, configPath)
 	tun.ConnectionRetries = config.ConnectionRetries
 	tun.WaitAndRetry = 3 * time.Second
 	tun.KeepAliveInterval = 10 * time.Second
@@ -470,6 +479,7 @@ func prepareTestEnv() error {
 	encryptedKeyPath = filepath.Join(testDir, "id_rsa_encrypted")
 	publicKeyPath = filepath.Join(testDir, "id_rsa.pub")
 	knownHostsPath = filepath.Join(testDir, "known_hosts")
+	configPath = filepath.Join(testDir, "config")
 	sshDir = testDir
 
 	fixtures := []map[string]string{

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -57,7 +57,7 @@ func TestServerOptions(t *testing.T) {
 			"",
 			"test",
 			"",
-			"",
+			"testdata/.ssh/config",
 			&Server{
 				Name:    "test",
 				Address: "127.0.0.1:2222",
@@ -70,7 +70,7 @@ func TestServerOptions(t *testing.T) {
 			"",
 			"test.something",
 			"",
-			"",
+			"testdata/.ssh/config",
 			&Server{
 				Name:    "test.something",
 				Address: "172.17.0.1:2223",
@@ -83,7 +83,7 @@ func TestServerOptions(t *testing.T) {
 			"mole_user",
 			"test:3333",
 			"testdata/.ssh/other_key",
-			"",
+			"testdata/.ssh/config",
 			&Server{
 				Name:    "test",
 				Address: "127.0.0.1:3333",
@@ -96,7 +96,7 @@ func TestServerOptions(t *testing.T) {
 			"",
 			"",
 			"",
-			"",
+			"testdata/.ssh/config",
 			nil,
 			errors.New(HostMissing),
 		},
@@ -421,7 +421,7 @@ func prepareTunnel(config *tunnelConfig) (tun *Tunnel, ssh net.Listener, hss []*
 		return
 	}
 
-	srv, _ := NewServer("mole", ssh.Addr().String(), "", "", "")
+	srv, _ := NewServer("mole", ssh.Addr().String(), "", "", "testdata/.ssh/config")
 
 	srv.Insecure = config.Insecure
 

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -35,6 +35,7 @@ func TestServerOptions(t *testing.T) {
 		user          string
 		address       string
 		key           string
+		config        string
 		expected      *Server
 		expectedError error
 	}{
@@ -42,6 +43,7 @@ func TestServerOptions(t *testing.T) {
 			"mole_user",
 			"172.17.0.10:2222",
 			"testdata/.ssh/id_rsa",
+			"testdata/.ssh/config",
 			&Server{
 				Name:    "172.17.0.10",
 				Address: "172.17.0.10:2222",
@@ -53,6 +55,7 @@ func TestServerOptions(t *testing.T) {
 		{
 			"",
 			"test",
+			"",
 			"",
 			&Server{
 				Name:    "test",
@@ -66,6 +69,7 @@ func TestServerOptions(t *testing.T) {
 			"",
 			"test.something",
 			"",
+			"",
 			&Server{
 				Name:    "test.something",
 				Address: "172.17.0.1:2223",
@@ -78,6 +82,7 @@ func TestServerOptions(t *testing.T) {
 			"mole_user",
 			"test:3333",
 			"testdata/.ssh/other_key",
+			"",
 			&Server{
 				Name:    "test",
 				Address: "127.0.0.1:3333",
@@ -90,13 +95,14 @@ func TestServerOptions(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			nil,
 			errors.New(HostMissing),
 		},
 	}
 
 	for _, test := range tests {
-		s, err := NewServer(test.user, test.address, test.key, "")
+		s, err := NewServer(test.user, test.address, test.key, "", test.config)
 		if err != nil {
 			if test.expectedError != nil {
 				if test.expectedError.Error() != err.Error() {
@@ -406,7 +412,7 @@ func prepareTunnel(config *tunnelConfig) (tun *Tunnel, ssh net.Listener, hss []*
 		return
 	}
 
-	srv, _ := NewServer("mole", ssh.Addr().String(), "", "")
+	srv, _ := NewServer("mole", ssh.Addr().String(), "", "", "")
 
 	srv.Insecure = config.Insecure
 


### PR DESCRIPTION
You can now pass SSH config file path as a --config flag parameter.