### PR TITLE
Fix copy of files to different partitions

### DIFF
--- a/alias/testdata/example.toml
+++ b/alias/testdata/example.toml
@@ -11,3 +11,4 @@ connection-retries = 3
 wait-and-retry = "3s"
 ssh-agent = ""
 timeout = "3s"
+config = ""

--- a/alias/testdata/test-env.toml
+++ b/alias/testdata/test-env.toml
@@ -11,3 +11,4 @@ connection-retries = 3
 wait-and-retry = "3s"
 ssh-agent = ""
 timeout = "3s"
+config = ""


### PR DESCRIPTION
This change fixes the issue with test setup where some files are copied to
`TMPDIR` and a "invalid cross-device link" error is raised, which
happens when a file is moved to different partitions.