### PR TITLE
Add support for parameters on rpc

### DIFF
--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -14,11 +14,11 @@ func TestHandler(t *testing.T) {
 	method := "test"
 	expectedResponse := `{"message":"test"}`
 
-	rpc.Register(method, func() (json.RawMessage, error) {
+	rpc.Register(method, func(params interface{}) (json.RawMessage, error) {
 		return json.RawMessage(expectedResponse), nil
 	})
 
-	response, err := rpc.Call(context.Background(), method)
+	response, err := rpc.Call(context.Background(), method, "param")
 	if err != nil {
 		t.Errorf("error while calling remote procedure: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestMethodNotRegistered(t *testing.T) {
 	method := "methodnotregistered"
 	expectedResponse := fmt.Sprintf(`{"code":-32601,"data":null,"message":"method %s not found"}`, method)
 
-	response, err := rpc.Call(context.Background(), method)
+	response, err := rpc.Call(context.Background(), method, "param")
 	if err != nil {
 		t.Errorf("error while calling remote procedure: %v", err)
 	}
@@ -56,11 +56,11 @@ func TestMethodWithError(t *testing.T) {
 	method := "testwitherror"
 	expectedResponse := fmt.Sprintf(`{"code":-32603,"data":null,"message":"error executing rpc method %s"}`, method)
 
-	rpc.Register(method, func() (json.RawMessage, error) {
+	rpc.Register(method, func(params interface{}) (json.RawMessage, error) {
 		return nil, fmt.Errorf("error")
 	})
 
-	response, err := rpc.Call(context.Background(), method)
+	response, err := rpc.Call(context.Background(), method, "param")
 	if err != nil {
 		t.Errorf("error while calling remote procedure: %v", err)
 	}


### PR DESCRIPTION
This change adds parameters to the functions that can be called
remotely.