### PR TITLE
Add pid file for any kind of instance

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -13,8 +13,8 @@ import (
 var (
 	stopCmd = &cobra.Command{
 		Use:   "stop [alias name or id]",
-		Short: "Stops a ssh tunnel",
-		Long:  "Stops a ssh tunnel by either an auto generated id or a given alias",
+		Short: "Stops an instance of mole ",
+		Long:  "Stops an instance of mole by either a given auto generated id or alias",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("alias name or id not provided")

--- a/fsutils/fsutils.go
+++ b/fsutils/fsutils.go
@@ -1,9 +1,23 @@
 package fsutils
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 )
+
+const (
+	InstancePidFile = "pid"
+	InstanceLogFile = "mole.log"
+)
+
+type InstanceDirInfo struct {
+	Id      string
+	Dir     string
+	PidFile string
+}
 
 // Dir returns the location where all mole related files are persisted,
 // including alias configuration and log files.
@@ -39,31 +53,112 @@ func CreateHomeDir() (string, error) {
 
 // CreateInstanceDir creates and then returns the location where all files
 // related to a specific mole instance are persisted.
-func CreateInstanceDir(appId string) (string, error) {
+// Along with the directory this function also created a pid file where the
+// instance process id is stored.
+func CreateInstanceDir(appId string) (*InstanceDirInfo, error) {
 	home, err := Dir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	d := filepath.Join(home, appId)
 
-	if _, err := os.Stat(d); os.IsNotExist(err) {
-		err := os.MkdirAll(d, 0755)
-		if err != nil {
-			return "", err
-		}
+	if _, err := os.Stat(d); !os.IsNotExist(err) {
+		return InstanceDir(appId)
 	}
 
-	return d, nil
+	err = os.MkdirAll(d, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	pfl, err := createPidFile(appId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InstanceDirInfo{
+		Id:      appId,
+		Dir:     d,
+		PidFile: pfl,
+	}, nil
 }
 
 // InstanceDir returns the location where all files related to a specific mole
 // instance are persisted.
-func InstanceDir(id string) (string, error) {
+func InstanceDir(id string) (*InstanceDirInfo, error) {
 	home, err := Dir()
+	if err != nil {
+		return nil, err
+	}
+
+	d := filepath.Join(home, id)
+
+	pfl, err := GetPidFileLocation(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InstanceDirInfo{
+		Id:      id,
+		Dir:     d,
+		PidFile: pfl,
+	}, nil
+}
+
+// GetPidFileLocation returns the file system location of the application
+// instance in the file system.
+func GetPidFileLocation(id string) (string, error) {
+	d, err := Dir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(home, id), nil
+	pfp := filepath.Join(d, id, InstancePidFile)
+
+	return pfp, nil
+}
+
+// GetLogFileLocation returns the file system location of the file where all
+// log messages are saved for an specific detached application instance.
+func GetLogFileLocation(id string) (string, error) {
+	d, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	lfp := filepath.Join(d, id, InstanceLogFile)
+
+	return lfp, nil
+}
+
+func createPidFile(id string) (string, error) {
+	pfl, err := GetPidFileLocation(id)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err = os.Stat(pfl); !os.IsNotExist(err) {
+		data, err := ioutil.ReadFile(pfl)
+		if err != nil {
+			return "", fmt.Errorf("something went wrong while reading from pid file %s: %v", pfl, err)
+		}
+
+		pid := string(data)
+
+		if pid != "" {
+			return "", fmt.Errorf("an instance of mole with pid %s seems to be already running", pid)
+		}
+
+	}
+
+	pf, err := os.Create(pfl)
+	if err != nil {
+		return "", fmt.Errorf("could not create pid file for application instance %s: %v", id, err)
+	}
+	defer pf.Close()
+	pf.WriteString(strconv.Itoa(os.Getpid()))
+
+	return pfl, nil
+
 }

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -1,0 +1,83 @@
+package fsutils_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/davrodpin/mole/fsutils"
+)
+
+var (
+	// home is a temporary directory that acts as the user home directory.
+	// It is used on most tests to validates files created by Mole and their
+	// contents.
+	home string
+)
+
+func TestCreateInstanceDir(t *testing.T) {
+	tests := []struct {
+		id        string
+		preCreate bool
+	}{
+		{id: "d34dbeef", preCreate: true},
+		{id: "f00d", preCreate: false},
+	}
+
+	for idx, test := range tests {
+		instanceDir := filepath.Join(home, ".mole", test.id)
+		pidFileLocation := filepath.Join(home, ".mole", test.id, fsutils.InstancePidFile)
+
+		if test.preCreate {
+			os.MkdirAll(instanceDir, 0755)
+			ioutil.WriteFile(pidFileLocation, []byte("1234"), 0644)
+		}
+
+		dirInfo, err := fsutils.CreateInstanceDir(test.id)
+
+		if err != nil {
+			t.Errorf("item %d: expected: nil; got %v", idx, err)
+		}
+
+		if test.id != dirInfo.Id {
+			t.Errorf("item %d: expected: %s; got: %s", idx, test.id, dirInfo.Id)
+		}
+
+		if instanceDir != dirInfo.Dir {
+			t.Errorf("item %d: expected: %s; got: %s", idx, instanceDir, dirInfo.Dir)
+		}
+
+		if pidFileLocation != dirInfo.PidFile {
+			t.Errorf("item %d: expected: %s; got: %s", idx, pidFileLocation, dirInfo.PidFile)
+		}
+
+		if _, err := os.Stat(dirInfo.Dir); os.IsNotExist(err) {
+			t.Errorf("item %d: no such instance directory %s", idx, dirInfo.Dir)
+		}
+
+		if _, err := os.Stat(dirInfo.PidFile); os.IsNotExist(err) {
+			t.Errorf("item %d: no such pid file %s", idx, dirInfo.PidFile)
+		}
+
+	}
+
+}
+
+func TestMain(m *testing.M) {
+	var err error
+
+	home, err = ioutil.TempDir("", "mole")
+	if err != nil {
+		os.Exit(1)
+	}
+
+	os.Setenv("HOME", home)
+	os.Setenv("USERPROFILE", home)
+
+	code := m.Run()
+
+	os.RemoveAll(home)
+
+	os.Exit(code)
+}

--- a/mole/app.go
+++ b/mole/app.go
@@ -7,17 +7,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/davrodpin/mole/fsutils"
 	"github.com/davrodpin/mole/rpc"
 
 	"github.com/hpcloud/tail"
-)
-
-const (
-	InstancePidFile = "pid"
-	InstanceLogFile = "mole.log"
 )
 
 // DetachedInstance holds the location to directories and files associated
@@ -41,38 +35,12 @@ func NewDetachedInstance(id string) (*DetachedInstance, error) {
 		return nil, fmt.Errorf("application instance id can't be empty")
 	}
 
-	_, err := fsutils.CreateInstanceDir(id)
+	dirInfo, err := fsutils.CreateInstanceDir(id)
 	if err != nil {
 		return nil, err
 	}
 
-	pfl, err := GetPidFileLocation(id)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err = os.Stat(pfl); !os.IsNotExist(err) {
-		data, err := ioutil.ReadFile(pfl)
-		if err != nil {
-			return nil, fmt.Errorf("something went wrong while reading from pid file %s: %v", pfl, err)
-		}
-
-		pid := string(data)
-
-		if pid != "" {
-			return nil, fmt.Errorf("an instance of mole with pid %s seems to be already running", pid)
-		}
-
-	}
-
-	pf, err := os.Create(pfl)
-	if err != nil {
-		return nil, fmt.Errorf("could not create pid file for application instance %s: %v", id, err)
-	}
-	defer pf.Close()
-	pf.WriteString(strconv.Itoa(os.Getpid()))
-
-	lfl, err := GetLogFileLocation(id)
+	lfl, err := fsutils.GetLogFileLocation(id)
 	if err != nil {
 		return nil, err
 	}
@@ -86,39 +54,13 @@ func NewDetachedInstance(id string) (*DetachedInstance, error) {
 	return &DetachedInstance{
 		Id:      id,
 		LogFile: lfl,
-		PidFile: pfl,
+		PidFile: dirInfo.PidFile,
 	}, nil
-}
-
-// GetPidFileLocation returns the file system location of the application
-// instance in the file system.
-func GetPidFileLocation(id string) (string, error) {
-	d, err := fsutils.Dir()
-	if err != nil {
-		return "", err
-	}
-
-	pfp := filepath.Join(d, id, InstancePidFile)
-
-	return pfp, nil
-}
-
-// GetLogFileLocation returns the file system location of the file where all
-// log messages are saved for an specific detached application instance.
-func GetLogFileLocation(id string) (string, error) {
-	d, err := fsutils.Dir()
-	if err != nil {
-		return "", err
-	}
-
-	lfp := filepath.Join(d, id, InstanceLogFile)
-
-	return lfp, nil
 }
 
 // ShowLogs displays all logs messages from a detached applications instance.
 func ShowLogs(id string, follow bool) error {
-	lfl, err := GetLogFileLocation(id)
+	lfl, err := fsutils.GetLogFileLocation(id)
 	if err != nil {
 		return err
 	}
@@ -141,7 +83,7 @@ func Rpc(id, method string, params interface{}) (string, error) {
 		return "", err
 	}
 
-	rf := filepath.Join(d, "rpc")
+	rf := filepath.Join(d.Dir, "rpc")
 
 	addr, err := ioutil.ReadFile(rf)
 	if err != nil {

--- a/mole/app_test.go
+++ b/mole/app_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/davrodpin/mole/fsutils"
 	"github.com/davrodpin/mole/mole"
 )
 
@@ -32,7 +33,7 @@ func TestDetachedInstanceFileLocations(t *testing.T) {
 		t.Errorf("pid file does not exist: %v", err)
 	}
 
-	lfl, err := mole.GetLogFileLocation(id)
+	lfl, err := fsutils.GetLogFileLocation(id)
 	if err != nil {
 		t.Errorf("error retrieving log file location: %v", err)
 	}
@@ -43,26 +44,11 @@ func TestDetachedInstanceFileLocations(t *testing.T) {
 
 }
 
-func TestDetachedInstanceAlreadyRunning(t *testing.T) {
-	id := "TestDetachedInstanceAlreadyRunning"
-
-	os.MkdirAll(filepath.Join(home, ".mole", id), 0755)
-	pidFileLocation := filepath.Join(home, ".mole", id, mole.InstancePidFile)
-	ioutil.WriteFile(pidFileLocation, []byte("1234"), 0644)
-
-	_, err := mole.NewDetachedInstance(id)
-
-	if err == nil {
-		t.Errorf("error expected but got nil")
-	}
-
-}
-
 func TestShowLogs(t *testing.T) {
 	id := "TestDetachedInstanceAlreadyRunning"
 
 	os.MkdirAll(filepath.Join(home, ".mole", id), 0755)
-	logFileLocation := filepath.Join(home, ".mole", id, mole.InstanceLogFile)
+	logFileLocation := filepath.Join(home, ".mole", id, fsutils.InstanceLogFile)
 	ioutil.WriteFile(logFileLocation, []byte("first log message\nsecond log message\nthird log message\n"), 0644)
 
 	err := mole.ShowLogs(id, false)


### PR DESCRIPTION
This change makes sure that both foreground and background (detached)
mole instances will have a correspoding pid file located on
`$HOME/.mole`, which is mainly needed to allows users to stop foreground
instances using the `stop` command.

Since foreground instances are considered ephemeral, the code will
remove the directory associated with that instance (i.e.
`$HOME/.mole/<id>` once the instances stops for whatever reason.

Also, this change makes the foreground instance identifier to be a
random string (out of a uuid4) instead of the process number.
