### PR TITLE
Return resolved addresses

### DIFF
--- a/mole/rpc.go
+++ b/mole/rpc.go
@@ -21,9 +21,9 @@ func ShowRpc(params interface{}) (json.RawMessage, error) {
 		return nil, fmt.Errorf("client configuration could not be found.")
 	}
 
-	conf := cli.Conf
+	runtime := cli.Runtime()
 
-	cj, err := json.Marshal(conf)
+	cj, err := json.Marshal(runtime)
 	if err != nil {
 		return nil, err
 	}

--- a/mole/runtime.go
+++ b/mole/runtime.go
@@ -62,3 +62,22 @@ func (ir InstancesRuntime) ToToml() (string, error) {
 
 	return buf.String(), nil
 }
+
+func (c *Client) Runtime() *Runtime {
+	runtime := Runtime(*c.Conf)
+
+	if c.Tunnel != nil {
+		source := &AddressInputList{}
+		destination := &AddressInputList{}
+
+		for _, channel := range c.Tunnel.Channels() {
+			source.Set(channel.Source)
+			destination.Set(channel.Destination)
+		}
+
+		runtime.Source = *source
+		runtime.Destination = *destination
+	}
+
+	return &runtime
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -448,6 +448,18 @@ func (t *Tunnel) keepAlive() {
 	}
 }
 
+// Channels returns a copy of all channels configured for the tunnel.
+func (t *Tunnel) Channels() []*SSHChannel {
+	channels := make([]*SSHChannel, len(t.channels))
+
+	for i, c := range t.channels {
+		cc := *c
+		channels[i] = &cc
+	}
+
+	return channels
+}
+
 func sshClientConfig(server Server) (*ssh.ClientConfig, error) {
 	var signers []ssh.Signer
 


### PR DESCRIPTION
This change makes the runtime information to return the addresses used
by the ssh channels instead of the input.
