### PR TITLE
Execute reconnection on a goroutine

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -245,7 +245,15 @@ func (t *Tunnel) Start() error {
 
 				log.Debugf("restablishing the tunnel after disconnection: %s", t)
 
-				t.connect()
+				// The reconnecion must happens on a goroutine to support the scenario
+				// where tunnel.Stop() is called while the tunnel.connect() is getting
+				// executed.
+				//
+				// In an event where tunnel.reconnect receives data from any point of the
+				// code rather than tunnel.dial(), which is evoked by tunnel.connect()
+				// this code needs to be updated to make sure tunnel.connect() is not
+				// schedule in two goroutines at the same time.
+				go t.connect()
 			}
 		case err := <-t.done:
 			if t.client != nil {


### PR DESCRIPTION
This change makes the connection to the ssh server and channels setup to
happen in a goroutine when mole is trying to reconnect.
The reason for this change is to allow the tunnel to be closed while the
attemp to reconnect is still in progress.
