### PR TITLE
Add support for multiple defined forwards in SSH config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/hpcloud/tail v1.0.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
-	github.com/kevinburke/ssh_config v0.0.0-20190630040420-2e50c441276c
+	github.com/kevinburke/ssh_config v1.1.0
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pelletier/go-buffruneio v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uia
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kevinburke/ssh_config v0.0.0-20190630040420-2e50c441276c h1:VAx3LRNjVNvjtgO7KFRuT/3aye/0zJvwn01rHSfoolo=
 github.com/kevinburke/ssh_config v0.0.0-20190630040420-2e50c441276c/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/kevinburke/ssh_config v1.1.0 h1:pH/t1WS9NzT8go394IqZeJTMHVm6Cr6ZJ6AQ+mdNo/o=
+github.com/kevinburke/ssh_config v1.1.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/tunnel/config_test.go
+++ b/tunnel/config_test.go
@@ -20,11 +20,11 @@ Host example2
 	LocalForward 8080 127.0.0.1:8080
 Host example3
 	LocalForward 9090 127.0.0.1:9090
+	LocalForward 9091 127.0.0.1:9091
 Host example4
 	RemoteForward 80 127.0.0.1:8080
 Host example5
 	RemoteForward 192.168.1.100:80 my-server:8080
-
 `
 
 	c, _ := ssh_config.Decode(strings.NewReader(config))
@@ -37,51 +37,54 @@ Host example5
 		{
 			"example1",
 			&SSHHost{
-				Hostname:     "172.17.0.1",
-				Port:         "3306",
-				User:         "john",
-				Key:          "/path/.ssh/id_rsa",
-				LocalForward: nil,
+				Hostname:      "172.17.0.1",
+				Port:          "3306",
+				User:          "john",
+				Key:           "/path/.ssh/id_rsa",
+				LocalForwards: nil,
 			},
 		},
 		{
 			"example2",
 			&SSHHost{
-				Hostname:     "",
-				Port:         "",
-				User:         "",
-				Key:          "",
-				LocalForward: &ForwardConfig{Source: "127.0.0.1:8080", Destination: "127.0.0.1:8080"},
+				Hostname:      "",
+				Port:          "",
+				User:          "",
+				Key:           "",
+				LocalForwards: []*ForwardConfig{&ForwardConfig{Source: "127.0.0.1:8080", Destination: "127.0.0.1:8080"}},
 			},
 		},
 		{
 			"example3",
 			&SSHHost{
-				Hostname:     "",
-				Port:         "",
-				User:         "",
-				Key:          "",
-				LocalForward: &ForwardConfig{Source: "127.0.0.1:9090", Destination: "127.0.0.1:9090"},
+				Hostname: "",
+				Port:     "",
+				User:     "",
+				Key:      "",
+				LocalForwards: []*ForwardConfig{
+					&ForwardConfig{Source: "127.0.0.1:9090", Destination: "127.0.0.1:9090"},
+					&ForwardConfig{Source: "127.0.0.1:9091", Destination: "127.0.0.1:9091"},
+				},
 			},
 		},
 		{
 			"example4",
 			&SSHHost{
-				Hostname:      "",
-				Port:          "",
-				User:          "",
-				Key:           "",
-				RemoteForward: &ForwardConfig{Source: "127.0.0.1:80", Destination: "127.0.0.1:8080"},
+				Hostname:       "",
+				Port:           "",
+				User:           "",
+				Key:            "",
+				RemoteForwards: []*ForwardConfig{&ForwardConfig{Source: "127.0.0.1:80", Destination: "127.0.0.1:8080"}},
 			},
 		},
 		{
 			"example5",
 			&SSHHost{
-				Hostname:      "",
-				Port:          "",
-				User:          "",
-				Key:           "",
-				RemoteForward: &ForwardConfig{Source: "192.168.1.100:80", Destination: "my-server:8080"},
+				Hostname:       "",
+				Port:           "",
+				User:           "",
+				Key:            "",
+				RemoteForwards: []*ForwardConfig{&ForwardConfig{Source: "192.168.1.100:80", Destination: "my-server:8080"}},
 			},
 		},
 	}

--- a/tunnel/testdata/dotssh/config
+++ b/tunnel/testdata/dotssh/config
@@ -17,3 +17,10 @@ Host hostWithLocalForward
     User mole_test
     IdentityFile ~/.ssh/id_rsa
 
+Host hostWithTwoLocalForwards
+    Hostname 127.0.0.1
+    Port 2222
+    LocalForward 8080 172.17.0.1:8080
+    LocalForward 9090 172.17.0.1:9090
+    User mole_test
+    IdentityFile ~/.ssh/id_rsa

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -338,6 +338,14 @@ func TestBuildSSHChannels(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			serverName:    "hostWithTwoLocalForwards",
+			source:        []string{},
+			destination:   []string{},
+			config:        "testdata/.ssh/config",
+			expected:      2,
+			expectedError: nil,
+		},
+		{
 			serverName:    "test",
 			source:        []string{":3360", ":8080"},
 			destination:   []string{":3360"},


### PR DESCRIPTION
Hi, I just started playing with mole. It's looking good!

I'd like to use multiple `LocalForward` directives from my `~/.ssh/config`. Currently, the code is written to get a scalar instance of the `LocalForward` key when it's valid to have any number of these options defined. This PR was tested locally, and I added some unit tests to validate behavior, as well.

While working on the code, I took the liberty of updating the kevinburke/ssh_config module to the latest release. Feel free to roll that back.
