### PR TITLE
Use default config when not set in <alias>.toml

### DIFF
--- a/mole/mole.go
+++ b/mole/mole.go
@@ -333,7 +333,9 @@ func (c *Configuration) Merge(al *alias.Alias, givenFlags []string) error {
 	}
 	c.Timeout = tim
 
-	c.SshConfig = al.SshConfig
+	if al.SshConfig != "" {
+		c.SshConfig = al.SshConfig
+	}
 
 	c.Rpc = al.Rpc
 

--- a/mole/mole_test.go
+++ b/mole/mole_test.go
@@ -68,6 +68,29 @@ func TestAliasMerge(t *testing.T) {
 				Detach:   true,
 			},
 		},
+		{
+			&alias.Alias{
+				Verbose:           false,
+				Insecure:          false,
+				Detach:            false,
+				Source:            []string{"127.0.0.1:80"},
+				Destination:       []string{"172.17.0.100:8080"},
+				Server:            "user@example.com:22",
+				Key:               "path/to/key/1",
+				KeepAliveInterval: "3s",
+				ConnectionRetries: 3,
+				WaitAndRetry:      "10s",
+				SshAgent:          "path/to/sshagent",
+				Timeout:           "3s",
+			},
+			[]string{},
+			mole.Configuration{
+				SshConfig: "path/to/config",
+			},
+			mole.Configuration{
+				SshConfig: "path/to/config",
+			},
+		},
 	}
 
 	for id, test := range tests {
@@ -75,15 +98,18 @@ func TestAliasMerge(t *testing.T) {
 		conf.Merge(test.alias, test.givenFlags)
 
 		if test.expected.Verbose != conf.Verbose {
-			t.Errorf("alias verbose doesn't match on test %d: expected: %t, value: %t", id, test.expected.Verbose, test.alias.Verbose)
+			t.Errorf("verbose doesn't match on test %d: expected: %t, value: %t", id, test.expected.Verbose, conf.Verbose)
 		}
 
 		if test.expected.Insecure != conf.Insecure {
-			t.Errorf("alias insecure doesn't match on test %d: expected: %t, value: %t", id, test.expected.Insecure, test.alias.Insecure)
+			t.Errorf("insecure doesn't match on test %d: expected: %t, value: %t", id, test.expected.Insecure, conf.Insecure)
 		}
 
 		if test.expected.Detach != conf.Detach {
-			t.Errorf("alias detach doesn't match on test %d: expected: %t, value: %t", id, test.expected.Detach, test.alias.Detach)
+			t.Errorf("detach doesn't match on test %d: expected: %t, value: %t", id, test.expected.Detach, conf.Detach)
+		}
+		if test.expected.SshConfig != conf.SshConfig {
+			t.Errorf("sshConfig doesn't match on test %d: expected: %s, value: %s", id, test.expected.SshConfig, conf.SshConfig)
 		}
 	}
 


### PR DESCRIPTION
Addresses #156

Since the value from `alias` is always assigned, it overwrites the default value (`$HOME/.ssh/config`). Checking whether `alias.SshConfig` is empty before overwriting fixes this.

This PR only addresses `SshConfig`. I guess it would make sense to go through the other options as well, to see which ones should not always be overwritten.